### PR TITLE
Add FormName to the Referral model

### DIFF
--- a/BrokerageApi.Tests/V1/E2ETests/ReferralTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/ReferralTests.cs
@@ -44,7 +44,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "88114daf-788b-48af-917b-996420afbf61",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 UrgentSince = null
             };
 
@@ -56,7 +56,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             Assert.That(response.WorkflowId, Is.EqualTo("88114daf-788b-48af-917b-996420afbf61"));
             Assert.That(response.WorkflowType, Is.EqualTo(WorkflowType.Assessment));
             Assert.That(response.SocialCareId, Is.EqualTo("33556688"));
-            Assert.That(response.Name, Is.EqualTo("A Service User"));
+            Assert.That(response.ResidentName, Is.EqualTo("A Service User"));
             Assert.That(response.UrgentSince, Is.Null);
             Assert.That(response.AssignedTo, Is.Null);
             Assert.That(response.Status, Is.EqualTo(ReferralStatus.Unassigned));
@@ -74,7 +74,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "88114daf-788b-48af-917b-996420afbf61",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 UrgentSince = urgentSince
             };
 
@@ -86,7 +86,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             Assert.That(response.WorkflowId, Is.EqualTo("88114daf-788b-48af-917b-996420afbf61"));
             Assert.That(response.WorkflowType, Is.EqualTo(WorkflowType.Assessment));
             Assert.That(response.SocialCareId, Is.EqualTo("33556688"));
-            Assert.That(response.Name, Is.EqualTo("A Service User"));
+            Assert.That(response.ResidentName, Is.EqualTo("A Service User"));
             Assert.That(response.UrgentSince, Is.EqualTo(urgentSince));
             Assert.That(response.AssignedTo, Is.Null);
             Assert.That(response.Status, Is.EqualTo(ReferralStatus.Unassigned));
@@ -105,7 +105,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -114,7 +114,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "b018672b-a169-4b35-afa7-b8a9344073c1",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.InReview
             };
 
@@ -123,7 +123,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "755caa62-3602-4229-90da-e30199a0336d",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -133,7 +133,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "ff245519-a28e-426c-ad13-4459216a2b2f",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.OnHold
             };
 
@@ -142,7 +142,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "c265bf16-dbc4-4d6d-afdf-9f9fd4ec7d14",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.Archived
             };
 
@@ -151,7 +151,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "3e48adb1-0ca2-456c-845a-efcd4eca4554",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.InProgress
             };
@@ -161,7 +161,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "9cab0511-094f-4d6b-ba81-7246ec0dc716",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.AwaitingApproval
             };
@@ -171,7 +171,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "174079ae-75b4-43b4-9d29-363e88e7dd40",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
@@ -212,7 +212,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -221,7 +221,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "b018672b-a169-4b35-afa7-b8a9344073c1",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.InReview
             };
 
@@ -249,7 +249,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
             };
 

--- a/BrokerageApi.Tests/V1/E2ETests/ReferralTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/ReferralTests.cs
@@ -43,6 +43,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "88114daf-788b-48af-917b-996420afbf61",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 UrgentSince = null
@@ -73,6 +74,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "88114daf-788b-48af-917b-996420afbf61",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 UrgentSince = urgentSince
@@ -104,6 +106,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
@@ -113,6 +116,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "b018672b-a169-4b35-afa7-b8a9344073c1",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.InReview
@@ -122,6 +126,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "755caa62-3602-4229-90da-e30199a0336d",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
@@ -132,6 +137,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "ff245519-a28e-426c-ad13-4459216a2b2f",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.OnHold
@@ -141,6 +147,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "c265bf16-dbc4-4d6d-afdf-9f9fd4ec7d14",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.Archived
@@ -150,6 +157,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "3e48adb1-0ca2-456c-845a-efcd4eca4554",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
@@ -160,6 +168,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "9cab0511-094f-4d6b-ba81-7246ec0dc716",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
@@ -170,6 +179,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "174079ae-75b4-43b4-9d29-363e88e7dd40",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
@@ -211,6 +221,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
@@ -220,6 +231,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "b018672b-a169-4b35-afa7-b8a9344073c1",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.InReview
@@ -248,6 +260,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             {
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned

--- a/BrokerageApi.Tests/V1/Gateways/ReferralGatewayTests.cs
+++ b/BrokerageApi.Tests/V1/Gateways/ReferralGatewayTests.cs
@@ -58,7 +58,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -67,7 +67,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "b018672b-a169-4b35-afa7-b8a9344073c1",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.InReview
             };
 
@@ -76,7 +76,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "755caa62-3602-4229-90da-e30199a0336d",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -86,7 +86,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "ff245519-a28e-426c-ad13-4459216a2b2f",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.OnHold
             };
 
@@ -95,7 +95,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "c265bf16-dbc4-4d6d-afdf-9f9fd4ec7d14",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.Archived
             };
 
@@ -104,7 +104,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "3e48adb1-0ca2-456c-845a-efcd4eca4554",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.InProgress
             };
@@ -114,7 +114,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "9cab0511-094f-4d6b-ba81-7246ec0dc716",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.AwaitingApproval
             };
@@ -124,7 +124,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "174079ae-75b4-43b4-9d29-363e88e7dd40",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
@@ -162,7 +162,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -171,7 +171,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = "b018672b-a169-4b35-afa7-b8a9344073c1",
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User",
+                ResidentName = "A Service User",
                 Status = ReferralStatus.InReview
             };
 
@@ -231,7 +231,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowId = workflowId,
                 WorkflowType = WorkflowType.Assessment,
                 SocialCareId = "33556688",
-                Name = "A Service User"
+                ResidentName = "A Service User"
             };
         }
     }

--- a/BrokerageApi.Tests/V1/Gateways/ReferralGatewayTests.cs
+++ b/BrokerageApi.Tests/V1/Gateways/ReferralGatewayTests.cs
@@ -57,6 +57,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
@@ -66,6 +67,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "b018672b-a169-4b35-afa7-b8a9344073c1",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.InReview
@@ -75,6 +77,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "755caa62-3602-4229-90da-e30199a0336d",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
@@ -85,6 +88,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "ff245519-a28e-426c-ad13-4459216a2b2f",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.OnHold
@@ -94,6 +98,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "c265bf16-dbc4-4d6d-afdf-9f9fd4ec7d14",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.Archived
@@ -103,6 +108,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "3e48adb1-0ca2-456c-845a-efcd4eca4554",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
@@ -113,6 +119,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "9cab0511-094f-4d6b-ba81-7246ec0dc716",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
@@ -123,6 +130,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "174079ae-75b4-43b4-9d29-363e88e7dd40",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 AssignedTo = "a.broker@hackney.gov.uk",
@@ -161,6 +169,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "3a386bf5-036d-47eb-ba58-704f3333e4fd",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.Unassigned
@@ -170,6 +179,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = "b018672b-a169-4b35-afa7-b8a9344073c1",
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
                 Status = ReferralStatus.InReview
@@ -230,6 +240,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             {
                 WorkflowId = workflowId,
                 WorkflowType = WorkflowType.Assessment,
+                FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User"
             };

--- a/BrokerageApi/V1/Boundary/Request/CreateReferralRequest.cs
+++ b/BrokerageApi/V1/Boundary/Request/CreateReferralRequest.cs
@@ -16,7 +16,7 @@ namespace BrokerageApi.V1.Boundary.Request
         public string SocialCareId { get; set; }
 
         [Required]
-        public string Name { get; set; }
+        public string ResidentName { get; set; }
 
         public DateTime? UrgentSince { get; set; }
     }

--- a/BrokerageApi/V1/Boundary/Request/CreateReferralRequest.cs
+++ b/BrokerageApi/V1/Boundary/Request/CreateReferralRequest.cs
@@ -13,6 +13,9 @@ namespace BrokerageApi.V1.Boundary.Request
         public WorkflowType WorkflowType { get; set; }
 
         [Required]
+        public string FormName { get; set; }
+
+        [Required]
         public string SocialCareId { get; set; }
 
         [Required]

--- a/BrokerageApi/V1/Boundary/Response/ReferralResponse.cs
+++ b/BrokerageApi/V1/Boundary/Response/ReferralResponse.cs
@@ -18,7 +18,7 @@ namespace BrokerageApi.V1.Boundary.Response
         public string SocialCareId { get; set; }
 
         [JsonProperty(Required = Required.DisallowNull)]
-        public string Name { get; set; }
+        public string ResidentName { get; set; }
 
         public DateTime? UrgentSince { get; set; }
 

--- a/BrokerageApi/V1/Boundary/Response/ReferralResponse.cs
+++ b/BrokerageApi/V1/Boundary/Response/ReferralResponse.cs
@@ -15,6 +15,9 @@ namespace BrokerageApi.V1.Boundary.Response
         public WorkflowType WorkflowType { get; set; }
 
         [JsonProperty(Required = Required.DisallowNull)]
+        public string FormName { get; set; }
+
+        [JsonProperty(Required = Required.DisallowNull)]
         public string SocialCareId { get; set; }
 
         [JsonProperty(Required = Required.DisallowNull)]

--- a/BrokerageApi/V1/Factories/EntityFactory.cs
+++ b/BrokerageApi/V1/Factories/EntityFactory.cs
@@ -11,6 +11,7 @@ namespace BrokerageApi.V1.Factories
             {
                 WorkflowId = request.WorkflowId,
                 WorkflowType = request.WorkflowType,
+                FormName = request.FormName,
                 SocialCareId = request.SocialCareId,
                 ResidentName = request.ResidentName,
                 UrgentSince = request.UrgentSince,

--- a/BrokerageApi/V1/Factories/EntityFactory.cs
+++ b/BrokerageApi/V1/Factories/EntityFactory.cs
@@ -12,7 +12,7 @@ namespace BrokerageApi.V1.Factories
                 WorkflowId = request.WorkflowId,
                 WorkflowType = request.WorkflowType,
                 SocialCareId = request.SocialCareId,
-                Name = request.Name,
+                ResidentName = request.ResidentName,
                 UrgentSince = request.UrgentSince,
                 Status = ReferralStatus.Unassigned
             };

--- a/BrokerageApi/V1/Factories/ResponseFactory.cs
+++ b/BrokerageApi/V1/Factories/ResponseFactory.cs
@@ -15,7 +15,7 @@ namespace BrokerageApi.V1.Factories
                 WorkflowId = referral.WorkflowId,
                 WorkflowType = referral.WorkflowType,
                 SocialCareId = referral.SocialCareId,
-                Name = referral.Name,
+                ResidentName = referral.ResidentName,
                 UrgentSince = referral.UrgentSince,
                 Status = referral.Status,
                 AssignedTo = referral.AssignedTo,

--- a/BrokerageApi/V1/Factories/ResponseFactory.cs
+++ b/BrokerageApi/V1/Factories/ResponseFactory.cs
@@ -14,6 +14,7 @@ namespace BrokerageApi.V1.Factories
                 Id = referral.Id,
                 WorkflowId = referral.WorkflowId,
                 WorkflowType = referral.WorkflowType,
+                FormName = referral.FormName,
                 SocialCareId = referral.SocialCareId,
                 ResidentName = referral.ResidentName,
                 UrgentSince = referral.UrgentSince,

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220401115735_ChangeNameToResidentName.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220401115735_ChangeNameToResidentName.Designer.cs
@@ -4,15 +4,17 @@ using System.Collections.Generic;
 using BrokerageApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220401115735_ChangeNameToResidentName")]
+    partial class ChangeNameToResidentName
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220401115735_ChangeNameToResidentName.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220401115735_ChangeNameToResidentName.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class ChangeNameToResidentName : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "name",
+                table: "referrals",
+                newName: "resident_name");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.RenameColumn(
+                name: "resident_name",
+                table: "referrals",
+                newName: "name");
+        }
+    }
+}

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220401121359_AddFormNameToReferral.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220401121359_AddFormNameToReferral.Designer.cs
@@ -4,15 +4,17 @@ using System.Collections.Generic;
 using BrokerageApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220401121359_AddFormNameToReferral")]
+    partial class AddFormNameToReferral
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220401121359_AddFormNameToReferral.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220401121359_AddFormNameToReferral.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddFormNameToReferral : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "form_name",
+                table: "referrals",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "form_name",
+                table: "referrals");
+        }
+    }
+}

--- a/BrokerageApi/V1/Infrastructure/Referral.cs
+++ b/BrokerageApi/V1/Infrastructure/Referral.cs
@@ -17,7 +17,7 @@ namespace BrokerageApi.V1.Infrastructure
         public string SocialCareId { get; set; }
 
         [Required]
-        public string Name { get; set; }
+        public string ResidentName { get; set; }
 
         public DateTime? UrgentSince { get; set; }
 

--- a/BrokerageApi/V1/Infrastructure/Referral.cs
+++ b/BrokerageApi/V1/Infrastructure/Referral.cs
@@ -14,6 +14,9 @@ namespace BrokerageApi.V1.Infrastructure
         public WorkflowType WorkflowType { get; set; }
 
         [Required]
+        public string FormName { get; set; }
+
+        [Required]
         public string SocialCareId { get; set; }
 
         [Required]


### PR DESCRIPTION
This is displayed on the kanban board so we need to be passed it in the initial request.

Also rename `Name` to `ResidentName` to clarify its purpose.
