### PR TITLE
Remove usage of Hackney.Core Google authentication

### DIFF
--- a/BrokerageApi.Tests/IntegrationTests.cs
+++ b/BrokerageApi.Tests/IntegrationTests.cs
@@ -1,14 +1,9 @@
 using System;
-using System.Collections.Generic;
 using System.Net;
 using System.Net.Http;
-using System.Net.Http.Headers;
 using System.Net.Sockets;
 using System.Text;
 using System.Threading.Tasks;
-using System.IdentityModel.Tokens.Jwt;
-using System.Security.Claims;
-using Microsoft.IdentityModel.Tokens;
 using BrokerageApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -40,9 +35,7 @@ namespace BrokerageApi.Tests
         public void BaseSetup()
         {
             _factory = new MockWebApplicationFactory<TStartup>(_builder);
-
             Client = _factory.CreateClient();
-            Client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", GenerateToken());
 
             _factory.Context.Database.Migrate();
             _transaction = _factory.Context.Database.BeginTransaction();
@@ -117,29 +110,6 @@ namespace BrokerageApi.Tests
             {
                 throw new Exception($"Result Serialisation Failed. Response Had Code {result.StatusCode}, Response: {responseContent}", e);
             }
-        }
-
-        private static string GenerateToken()
-        {
-            var securityKey = new SymmetricSecurityKey(Encoding.ASCII.GetBytes("super-secret-token"));
-            var tokenHandler = new JwtSecurityTokenHandler();
-            var tokenDescriptor = new SecurityTokenDescriptor
-            {
-                Subject = new ClaimsIdentity(new Claim[]
-                {
-                    new Claim("sub", "123456789012345678901"),
-                    new Claim("email", "a.broker@hackney.gov.uk"),
-                    new Claim("name", "A Broker"),
-                    new Claim("groups", "HackneyAll"),
-                    new Claim("groups", "saml-socialcarefinance-brokerage")
-                }),
-                Issuer = "Hackney",
-                IssuedAt = DateTime.UtcNow,
-                SigningCredentials = new SigningCredentials(securityKey, SecurityAlgorithms.HmacSha256Signature)
-            };
-
-            var token = tokenHandler.CreateToken(tokenDescriptor);
-            return tokenHandler.WriteToken(token);
         }
     }
 }

--- a/BrokerageApi.Tests/MockWebApplicationFactory.cs
+++ b/BrokerageApi.Tests/MockWebApplicationFactory.cs
@@ -32,8 +32,6 @@ namespace BrokerageApi.Tests
 
                 dbContext.Database.Migrate();
             });
-
-            Environment.SetEnvironmentVariable("REQUIRED_GOOGL_GROUPS", "saml-socialcarefinance-brokerage");
         }
 
         public BrokerageContext Context { get; set; }

--- a/BrokerageApi/BrokerageApi.csproj
+++ b/BrokerageApi/BrokerageApi.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.8.2" />
     <PackageReference Include="AWSXRayRecorder.Handlers.EntityFramework" Version="1.1.0" />
     <PackageReference Include="EFCore.NamingConventions" Version="5.0.2" />
-    <PackageReference Include="Hackney.Core.Authorization" Version="1.66.0" />
     <PackageReference Include="Microsoft.AspNetCore.HealthChecks" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.20" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />

--- a/BrokerageApi/Startup.cs
+++ b/BrokerageApi/Startup.cs
@@ -24,8 +24,6 @@ using Microsoft.Extensions.Logging;
 using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 using Swashbuckle.AspNetCore.SwaggerGen;
-using Hackney.Core.Authorization;
-using Hackney.Core.JWT;
 
 namespace BrokerageApi
 {
@@ -117,7 +115,6 @@ namespace BrokerageApi
             });
 
             services.AddSwaggerGenNewtonsoftSupport();
-            services.AddTokenFactory();
 
             ConfigureLogging(services, Configuration);
 
@@ -209,7 +206,6 @@ namespace BrokerageApi
                 }
             });
             app.UseSwagger();
-            app.UseGoogleGroupAuthorization();
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/BrokerageApi/serverless.yml
+++ b/BrokerageApi/serverless.yml
@@ -23,7 +23,6 @@ functions:
     role: lambdaExecutionRole
     environment:
       CONNECTION_STRING: Host=${ssm:/brokerage-api/${self:provider.stage}/postgres-hostname};Port=${ssm:/brokerage-api/${self:provider.stage}/postgres-port};Database=${ssm:/brokerage-api/${self:provider.stage}/postgres-database};Username=${ssm:/brokerage-api/${self:provider.stage}/postgres-username};Password=${ssm:/brokerage-api/${self:provider.stage}/postgres-password}
-      REQUIRED_GOOGL_GROUPS: ${ssm:/brokerage-api/${self:provider.stage}/required-google-groups}
     events:
       - http:
           path: /{proxy+}


### PR DESCRIPTION
The deployed APIs will use the Lambda authorizer to authenticate and verify the JWT payload and we'll need a fine-grained custom role provider for controlled access to individual API functions.
