### PR TITLE
Add authorisation for brokerage assistant and broker roles

### DIFF
--- a/BrokerageApi.Tests/V1/Infrastructure/UserRolesMiddlewareTests.cs
+++ b/BrokerageApi.Tests/V1/Infrastructure/UserRolesMiddlewareTests.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
 using BrokerageApi.V1.Controllers;
@@ -23,8 +25,64 @@ namespace BrokerageApi.Tests.V1.Infrastructure
         }
 
         [Test]
-        public async Task DoesGetRolesFromJWToken()
+        public async Task DoesGetRolesFromJwToken()
         {
+            // Add some users
+            var careChargesOfficer = new User()
+            {
+                Name = "Care Charges Officer",
+                Email = "care.chargesofficer@hackney.gov.uk",
+                IsActive = true,
+                Roles = new List<UserRole>() {
+                    UserRole.CareChargesOfficer
+                }
+            };
+
+            var brokerageAssistant = new User()
+            {
+                Name = "Brokerage Assistant",
+                Email = "brokerage.assistant@hackney.gov.uk",
+                IsActive = true,
+                Roles = new List<UserRole>() {
+                    UserRole.BrokerageAssistant
+                }
+            };
+
+            var approver = new User()
+            {
+                Name = "An Approver",
+                Email = "an.approver@hackney.gov.uk",
+                IsActive = true,
+                Roles = new List<UserRole>() {
+                    UserRole.Approver
+                }
+            };
+
+            var broker = new User()
+            {
+                Name = "A Broker",
+                Email = "a.broker@hackney.gov.uk",
+                IsActive = true,
+                Roles = new List<UserRole>() {
+                    UserRole.Broker
+                }
+            };
+
+            var deactivatedUser = new User()
+            {
+                Name = "Deactivated User",
+                Email = "deactivated.user@hackney.gov.uk",
+                IsActive = false,
+                Roles = new List<UserRole>()
+            };
+
+            await BrokerageContext.Users.AddAsync(careChargesOfficer);
+            await BrokerageContext.Users.AddAsync(brokerageAssistant);
+            await BrokerageContext.Users.AddAsync(approver);
+            await BrokerageContext.Users.AddAsync(broker);
+            await BrokerageContext.Users.AddAsync(deactivatedUser);
+            await BrokerageContext.SaveChangesAsync();
+
             // Ideally these could be moved to some kind of Data Provider, but
             // I couldn't get [DataTestMethod] or [DataRow] to work
             // Fake JWT's created at jwt.io
@@ -32,32 +90,32 @@ namespace BrokerageApi.Tests.V1.Infrastructure
             // "care.chargesofficer@hackney.gov.uk"
             jwtTests.Add(
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJjYXJlLmNoYXJnZXNvZmZpY2VyQGhhY2tuZXkuZ292LnVrIiwiaWF0IjoyfQ.2_UG2zfthTPNbk7Bxzpbb2NxyAkkW_PI26NgF5PDRPY",
-                "care_charges_officer");
+                "CareChargesOfficer");
             // "brokerage.assistant@hackney.gov.uk"
             jwtTests.Add(
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJicm9rZXJhZ2UuYXNzaXN0YW50QGhhY2tuZXkuZ292LnVrIiwiaWF0IjoyfQ.9d4CuUlDEPeNjn3rdkN5NNZCFZptQ0M2MmB11Fg-o90",
-                "brokerage_assistant");
+                "BrokerageAssistant");
             // "an.approver@hackney.gov.uk"
             jwtTests.Add(
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJhbi5hcHByb3ZlckBoYWNrbmV5Lmdvdi51ayIsImlhdCI6Mn0._Re7Z8g3XELlWF_6KwWKiyRrpjEMsGGunpHwb7xK_qk",
-                "approver");
+                "Approver");
             // "a.broker@hackney.gov.uk"
             jwtTests.Add(
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJhLmJyb2tlckBoYWNrbmV5Lmdvdi51ayIsImlhdCI6Mn0.LxrOZU8uz-zHtMwR6AseCApmLfKqkNsFvlwHd9drpd4",
-                "broker");
+                "Broker");
             // "deactivated.user@hackney.gov.uk"
             jwtTests.Add(
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJkZWFjdGl2YXRlZC51c2VyQGhhY2tuZXkuZ292LnVrIiwiaWF0IjoyfQ.QAFwwEQerIx-9GlRWz14ti-jrD07SYMZnCMvuTtbAnU",
-                ""); // empty, no roles
+                ""); // Should be empty, no roles
             // "billy.nomates@hackney.gov.uk"
             jwtTests.Add(
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJiaWxseS5ub21hdGVzQGhhY2tuZXkuZ292LnVrIiwiaWF0IjoyfQ.hEHh8uLF6SgHcYLQeytkxU5OvUqo80zlIKl-s9D3yMY",
-                "" // not actually sure
+                "" // Doesn't exist in table
             );
             // no email in JWT
             jwtTests.Add(
                 "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoyfQ.NxI-RFXwMfbphQ9yozZgTmGr31IAhPv8bnVg61dKPRg",
-                "" // not actually sure
+                "" // Should be empty
             );
 
             foreach (string jwt in jwtTests)

--- a/BrokerageApi.Tests/V1/Infrastructure/UserRolesMiddlewareTests.cs
+++ b/BrokerageApi.Tests/V1/Infrastructure/UserRolesMiddlewareTests.cs
@@ -1,0 +1,81 @@
+using System.Collections.Specialized;
+using System.Threading.Tasks;
+using BrokerageApi.V1.Controllers;
+using BrokerageApi.V1.Gateways;
+using BrokerageApi.V1.Infrastructure;
+using FluentAssertions;
+using Microsoft.AspNetCore.Http;
+using NUnit.Framework;
+
+namespace BrokerageApi.Tests.V1.Infrastructure
+{
+    [TestFixture]
+    public class UserRolesMiddlewareTest : DatabaseTests
+    {
+        private UserRolesMiddleware _sut;
+        private UserGateway _userGateway;
+
+        [SetUp]
+        public void Init()
+        {
+            _sut = new UserRolesMiddleware(null);
+            _userGateway = new UserGateway(BrokerageContext);
+        }
+
+        [Test]
+        public async Task DoesGetRolesFromJWToken()
+        {
+            // Ideally these could be moved to some kind of Data Provider, but
+            // I couldn't get [DataTestMethod] or [DataRow] to work
+            // Fake JWT's created at jwt.io
+            var jwtTests = new NameValueCollection();
+            // "care.chargesofficer@hackney.gov.uk"
+            jwtTests.Add(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJjYXJlLmNoYXJnZXNvZmZpY2VyQGhhY2tuZXkuZ292LnVrIiwiaWF0IjoyfQ.2_UG2zfthTPNbk7Bxzpbb2NxyAkkW_PI26NgF5PDRPY",
+                "care_charges_officer");
+            // "brokerage.assistant@hackney.gov.uk"
+            jwtTests.Add(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJicm9rZXJhZ2UuYXNzaXN0YW50QGhhY2tuZXkuZ292LnVrIiwiaWF0IjoyfQ.9d4CuUlDEPeNjn3rdkN5NNZCFZptQ0M2MmB11Fg-o90",
+                "brokerage_assistant");
+            // "an.approver@hackney.gov.uk"
+            jwtTests.Add(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJhbi5hcHByb3ZlckBoYWNrbmV5Lmdvdi51ayIsImlhdCI6Mn0._Re7Z8g3XELlWF_6KwWKiyRrpjEMsGGunpHwb7xK_qk",
+                "approver");
+            // "a.broker@hackney.gov.uk"
+            jwtTests.Add(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJhLmJyb2tlckBoYWNrbmV5Lmdvdi51ayIsImlhdCI6Mn0.LxrOZU8uz-zHtMwR6AseCApmLfKqkNsFvlwHd9drpd4",
+                "broker");
+            // "deactivated.user@hackney.gov.uk"
+            jwtTests.Add(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJkZWFjdGl2YXRlZC51c2VyQGhhY2tuZXkuZ292LnVrIiwiaWF0IjoyfQ.QAFwwEQerIx-9GlRWz14ti-jrD07SYMZnCMvuTtbAnU",
+                ""); // empty, no roles
+            // "billy.nomates@hackney.gov.uk"
+            jwtTests.Add(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiZW1haWwiOiJiaWxseS5ub21hdGVzQGhhY2tuZXkuZ292LnVrIiwiaWF0IjoyfQ.hEHh8uLF6SgHcYLQeytkxU5OvUqo80zlIKl-s9D3yMY",
+                "" // not actually sure
+            );
+            // no email in JWT
+            jwtTests.Add(
+                "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoyfQ.NxI-RFXwMfbphQ9yozZgTmGr31IAhPv8bnVg61dKPRg",
+                "" // not actually sure
+            );
+
+            foreach (string jwt in jwtTests)
+            {
+                string shouldMatch = jwtTests[jwt];
+
+                // Arrange
+                var httpContext = new DefaultHttpContext();
+
+                httpContext.HttpContext.Request.Headers.Add(Constants.Authorization, jwt);
+
+                // Act
+                await _sut.InvokeAsync(httpContext, _userGateway).ConfigureAwait(false);
+
+                string userRoles = httpContext.HttpContext.Request.Headers[Constants.UserRoles];
+
+                userRoles.Should().BeEquivalentTo(shouldMatch);
+            }
+        }
+    }
+}

--- a/BrokerageApi.Tests/V1/UseCase/GetUserByEmailUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetUserByEmailUseCaseTests.cs
@@ -1,0 +1,45 @@
+using AutoFixture;
+using System;
+using System.Threading.Tasks;
+using BrokerageApi.Tests.V1.Helpers;
+using BrokerageApi.V1.Gateways;
+using BrokerageApi.V1.Gateways.Interfaces;
+using BrokerageApi.V1.Infrastructure;
+using BrokerageApi.V1.UseCase;
+using FluentAssertions;
+using Moq;
+using NUnit.Framework;
+
+namespace BrokerageApi.Tests.V1.UseCase
+{
+    public class GetUserByEmailUseCaseTests
+    {
+        private Mock<IUserGateway> _mockUserGateway;
+        private GetUserByEmailUseCase _classUnderTest;
+        private Fixture _fixture;
+
+        [SetUp]
+        public void Setup()
+        {
+            _fixture = FixtureHelpers.Fixture;
+            _mockUserGateway = new Mock<IUserGateway>();
+            _classUnderTest = new GetUserByEmailUseCase(_mockUserGateway.Object);
+        }
+
+        [Test]
+        public async Task GetUser()
+        {
+            // Arrange
+            var user = _fixture.Create<User>();
+            _mockUserGateway
+                .Setup(x => x.GetByEmailAsync(user.Email))
+                .ReturnsAsync(user);
+
+            // Act
+            var result = await _classUnderTest.ExecuteAsync(user.Email);
+
+            // Assert
+            result.Should().BeEquivalentTo(user);
+        }
+    }
+}

--- a/BrokerageApi/Startup.cs
+++ b/BrokerageApi/Startup.cs
@@ -210,6 +210,7 @@ namespace BrokerageApi
             });
             app.UseSwagger();
             app.UseGoogleGroupAuthorization();
+            app.UseUserRoles();
             app.UseRouting();
             app.UseEndpoints(endpoints =>
             {

--- a/BrokerageApi/V1/Constants.cs
+++ b/BrokerageApi/V1/Constants.cs
@@ -2,6 +2,9 @@ namespace BrokerageApi.V1.Controllers
 {
     public static class Constants
     {
+        // HTTP Headers
+        public const string Authorization = "Authorization";
         public const string CorrelationId = "x-correlation-id";
+        public const string UserRoles = "x-user-roles";
     }
 }

--- a/BrokerageApi/V1/Gateways/Interfaces/IUserGateway.cs
+++ b/BrokerageApi/V1/Gateways/Interfaces/IUserGateway.cs
@@ -7,5 +7,7 @@ namespace BrokerageApi.V1.Gateways.Interfaces
     public interface IUserGateway
     {
         public Task<IEnumerable<User>> GetAllAsync(UserRole? role = null);
+
+        public Task<User> GetByEmailAsync(string email);
     }
 }

--- a/BrokerageApi/V1/Gateways/UserGateway.cs
+++ b/BrokerageApi/V1/Gateways/UserGateway.cs
@@ -34,5 +34,12 @@ namespace BrokerageApi.V1.Gateways
                     .ToListAsync();
             }
         }
+
+        public async Task<User> GetByEmailAsync(string email)
+        {
+            return await _context.Users
+                .Where(u => u.Email == email)
+                .SingleOrDefaultAsync();
+        }
     }
 }

--- a/BrokerageApi/V1/UseCase/GetUserByEmailUseCase.cs
+++ b/BrokerageApi/V1/UseCase/GetUserByEmailUseCase.cs
@@ -1,0 +1,22 @@
+using System.Threading.Tasks;
+using BrokerageApi.V1.Gateways.Interfaces;
+using BrokerageApi.V1.Infrastructure;
+using BrokerageApi.V1.UseCase.Interfaces;
+
+namespace BrokerageApi.V1.UseCase
+{
+    public class GetUserByEmailUseCase : IGetUserByEmailUseCase
+    {
+        private readonly IUserGateway _userGateway;
+
+        public GetUserByEmailUseCase(IUserGateway userGateway)
+        {
+            _userGateway = userGateway;
+        }
+
+        public async Task<User> ExecuteAsync(string email)
+        {
+            return await _userGateway.GetByEmailAsync(email);
+        }
+    }
+}

--- a/BrokerageApi/V1/UseCase/Interfaces/IGetUserByEmailUseCase.cs
+++ b/BrokerageApi/V1/UseCase/Interfaces/IGetUserByEmailUseCase.cs
@@ -1,0 +1,10 @@
+using System.Threading.Tasks;
+using BrokerageApi.V1.Infrastructure;
+
+namespace BrokerageApi.V1.UseCase.Interfaces
+{
+    public interface IGetUserByEmailUseCase
+    {
+        public Task<User> ExecuteAsync(string email);
+    }
+}

--- a/BrokerageApi/V1/UserRolesMiddleware.cs
+++ b/BrokerageApi/V1/UserRolesMiddleware.cs
@@ -25,6 +25,10 @@ namespace BrokerageApi.V1.Controllers
             // Get email from JWT
             var handler = new JwtSecurityTokenHandler();
             string authHeader = context.Request.Headers[Constants.Authorization];
+
+            // Remove `Bearer ` if present
+            authHeader = authHeader.Replace("Bearer ", "");
+
             var jsonToken = handler.ReadToken(authHeader);
             var jsonString = jsonToken.ToString();
 
@@ -36,10 +40,11 @@ namespace BrokerageApi.V1.Controllers
             // handler.ValidateToken(/* some service */)
 
             // Get roles from users table, set at x- header
-            string email = authObject["email"].ToString();
+            string email = authObject["email"]?.ToString();
             var user = await userGateway.GetByEmailAsync(email);
             if (user == null)
             {
+                Console.WriteLine("No match for " + email);
                 context.Request.Headers[Constants.UserRoles] = "";
             }
             else

--- a/BrokerageApi/V1/UserRolesMiddleware.cs
+++ b/BrokerageApi/V1/UserRolesMiddleware.cs
@@ -1,0 +1,65 @@
+using System;
+using System.IdentityModel.Tokens.Jwt;
+using System.Threading.Tasks;
+using BrokerageApi.V1.Gateways.Interfaces;
+using BrokerageApi.V1.UseCase.Interfaces;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Newtonsoft.Json.Linq;
+
+namespace BrokerageApi.V1.Controllers
+{
+    public class UserRolesMiddleware
+    {
+        private readonly RequestDelegate _next;
+
+        public UserRolesMiddleware(RequestDelegate next)
+        {
+            _next = next;
+        }
+
+        public async Task InvokeAsync(HttpContext context,
+            IUserGateway userGateway
+        )
+        {
+            // Get email from JWT
+            var handler = new JwtSecurityTokenHandler();
+            string authHeader = context.Request.Headers[Constants.Authorization];
+            var jsonToken = handler.ReadToken(authHeader);
+            var jsonString = jsonToken.ToString();
+
+            // Until we can authenticate, split by '}.{'
+            string[] tokens = jsonString.Split(new[] { "}.{" }, StringSplitOptions.None);
+            var authObject = JObject.Parse("{" + tokens[1]);
+
+            // Proper authentication will prevent the above - will be something like this
+            // handler.ValidateToken(/* some service */)
+
+            // Get roles from users table, set at x- header
+            string email = authObject["email"].ToString();
+            var user = await userGateway.GetByEmailAsync(email);
+            if (user == null)
+            {
+                context.Request.Headers[Constants.UserRoles] = "";
+            }
+            else
+            {
+                context.Request.Headers[Constants.UserRoles] =
+                    String.Join(",", user.Roles.ToArray());
+            }
+
+            // Hand over to next middleware
+            if (_next != null)
+                await _next(context).ConfigureAwait(false);
+        }
+    }
+
+    public static class UserRolesMiddlewareExtensions
+    {
+        public static IApplicationBuilder UseUserRoles(
+            this IApplicationBuilder builder)
+        {
+            return builder.UseMiddleware<UserRolesMiddleware>();
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # LBH ASC Brokerage API
 
 The ASB Brokerage API is the backend for the Adult Social Care Broker tool.
+
+## Setup
+
+We recommend using [Docker Desktop][1] to get setup quickly. Once installed, set the environment variable `LBHPACKAGESTOKEN` to a Github access token, with the  `read:packages` scope enabled.
+
+Run `make test` to build test, and `make serve` to bring up the server. Swagger is available at [:5100/swagger][3].
+
+[1]: https://www.docker.com/products/docker-desktop
+[2]: https://github.com/settings/tokens/new?scopes=read:packages&description=LBH+Packages+Token
+[3]: http://localhost:5100/swagger


### PR DESCRIPTION
## Link to JIRA ticket
[FBT-7](https://hackney.atlassian.net/jira/software/c/projects/FBT/boards/73?modal=detail&selectedIssue=FBT-7)

## Describe this PR
Adds a UserRolesMiddleware, which compares the email given in the JWT header to our users table, and set the roles in a `x-user-roles` header

### *What is the problem we're trying to solve*
API calls need to know what roles the user making the request has.

### *What changes have we introduced*
A new [Middleware layer](https://github.com/LBHackney-IT/lbh-asc-brokerage-api/blob/3a8397a487c87c396321f21b322a8a895da95226/BrokerageApi/V1/UserRolesMiddleware.cs), a new method [GetByEmailAsync](https://github.com/LBHackney-IT/lbh-asc-brokerage-api/blob/29f5dce33dab47078746008ed2b46cb7a088423b/BrokerageApi/V1/Gateways/UserGateway.cs#L38-L43) in UserGateway and relevant tests

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*
We need to authenticate the JWT - the code at [UserRolesMiddleware.cs:40](https://github.com/LBHackney-IT/lbh-asc-brokerage-api/blob/3a8397a487c87c396321f21b322a8a895da95226/BrokerageApi/V1/UserRolesMiddleware.cs#L40) gives an example.