### PR TITLE
Collect primary support reason in referral

### DIFF
--- a/BrokerageApi.Tests/V1/E2ETests/ReferralTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/ReferralTests.cs
@@ -46,6 +46,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 UrgentSince = null,
                 Note = "Some notes"
             };
@@ -59,6 +60,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             Assert.That(response.WorkflowType, Is.EqualTo(WorkflowType.Assessment));
             Assert.That(response.SocialCareId, Is.EqualTo("33556688"));
             Assert.That(response.ResidentName, Is.EqualTo("A Service User"));
+            Assert.That(response.PrimarySupportReason, Is.EqualTo("Physical Support"));
             Assert.That(response.UrgentSince, Is.Null);
             Assert.That(response.AssignedTo, Is.Null);
             Assert.That(response.Status, Is.EqualTo(ReferralStatus.Unassigned));
@@ -79,6 +81,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 UrgentSince = urgentSince,
                 Note = "Some notes"
             };
@@ -92,6 +95,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             Assert.That(response.WorkflowType, Is.EqualTo(WorkflowType.Assessment));
             Assert.That(response.SocialCareId, Is.EqualTo("33556688"));
             Assert.That(response.ResidentName, Is.EqualTo("A Service User"));
+            Assert.That(response.PrimarySupportReason, Is.EqualTo("Physical Support"));
             Assert.That(response.UrgentSince, Is.EqualTo(urgentSince));
             Assert.That(response.AssignedTo, Is.Null);
             Assert.That(response.Status, Is.EqualTo(ReferralStatus.Unassigned));
@@ -113,6 +117,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -123,6 +128,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.InReview
             };
 
@@ -133,6 +139,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -144,6 +151,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.OnHold
             };
 
@@ -154,6 +162,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Archived
             };
 
@@ -164,6 +173,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.InProgress
             };
@@ -175,6 +185,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.AwaitingApproval
             };
@@ -186,6 +197,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
@@ -228,6 +240,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -238,6 +251,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.InReview
             };
 
@@ -269,6 +283,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -279,6 +294,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.InReview
             };
 
@@ -289,6 +305,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "api.user@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -300,6 +317,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "other.user@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -311,6 +329,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.OnHold
             };
 
@@ -321,6 +340,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Archived
             };
 
@@ -331,6 +351,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "api.user@hackney.gov.uk",
                 Status = ReferralStatus.InProgress
             };
@@ -342,6 +363,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "api.user@hackney.gov.uk",
                 Status = ReferralStatus.AwaitingApproval
             };
@@ -353,6 +375,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "api.user@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
@@ -399,6 +422,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "api.user@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -410,6 +434,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "api.user@hackney.gov.uk",
                 Status = ReferralStatus.InProgress
             };
@@ -442,6 +467,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -473,6 +499,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -516,6 +543,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.InProgress,
                 AssignedTo = "other.broker@hackney.gov.uk"
             };

--- a/BrokerageApi.Tests/V1/Gateways/ReferralGatewayTests.cs
+++ b/BrokerageApi.Tests/V1/Gateways/ReferralGatewayTests.cs
@@ -60,6 +60,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -70,6 +71,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.InReview
             };
 
@@ -80,6 +82,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -91,6 +94,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.OnHold
             };
 
@@ -101,6 +105,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Archived
             };
 
@@ -111,6 +116,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.InProgress
             };
@@ -122,6 +128,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.AwaitingApproval
             };
@@ -133,6 +140,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
@@ -172,6 +180,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -182,6 +191,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.InReview
             };
 
@@ -207,6 +217,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Unassigned
             };
 
@@ -217,6 +228,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.InReview
             };
 
@@ -227,6 +239,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -238,6 +251,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "other.broker@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -249,6 +263,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.OnHold
             };
 
@@ -259,6 +274,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 Status = ReferralStatus.Archived
             };
 
@@ -269,6 +285,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.InProgress
             };
@@ -280,6 +297,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.AwaitingApproval
             };
@@ -291,6 +309,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
@@ -332,6 +351,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Assigned
             };
@@ -343,6 +363,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
                 ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support",
                 AssignedTo = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.InProgress
             };
@@ -404,7 +425,8 @@ namespace BrokerageApi.Tests.V1.Gateways
                 WorkflowType = WorkflowType.Assessment,
                 FormName = "Care act assessment",
                 SocialCareId = "33556688",
-                ResidentName = "A Service User"
+                ResidentName = "A Service User",
+                PrimarySupportReason = "Physical Support"
             };
         }
     }

--- a/BrokerageApi/V1/Boundary/Request/CreateReferralRequest.cs
+++ b/BrokerageApi/V1/Boundary/Request/CreateReferralRequest.cs
@@ -21,6 +21,8 @@ namespace BrokerageApi.V1.Boundary.Request
         [Required]
         public string ResidentName { get; set; }
 
+        public string PrimarySupportReason { get; set; }
+
         public DateTime? UrgentSince { get; set; }
 
         public string Note { get; set; }

--- a/BrokerageApi/V1/Boundary/Response/ReferralResponse.cs
+++ b/BrokerageApi/V1/Boundary/Response/ReferralResponse.cs
@@ -23,6 +23,8 @@ namespace BrokerageApi.V1.Boundary.Response
         [JsonProperty(Required = Required.DisallowNull)]
         public string ResidentName { get; set; }
 
+        public string PrimarySupportReason { get; set; }
+
         public DateTime? UrgentSince { get; set; }
 
         public string AssignedTo { get; set; }

--- a/BrokerageApi/V1/Factories/EntityFactory.cs
+++ b/BrokerageApi/V1/Factories/EntityFactory.cs
@@ -14,6 +14,7 @@ namespace BrokerageApi.V1.Factories
                 FormName = request.FormName,
                 SocialCareId = request.SocialCareId,
                 ResidentName = request.ResidentName,
+                PrimarySupportReason = request.PrimarySupportReason,
                 UrgentSince = request.UrgentSince,
                 Status = ReferralStatus.Unassigned,
                 Note = request.Note

--- a/BrokerageApi/V1/Factories/ResponseFactory.cs
+++ b/BrokerageApi/V1/Factories/ResponseFactory.cs
@@ -39,6 +39,7 @@ namespace BrokerageApi.V1.Factories
                 FormName = referral.FormName,
                 SocialCareId = referral.SocialCareId,
                 ResidentName = referral.ResidentName,
+                PrimarySupportReason = referral.PrimarySupportReason,
                 UrgentSince = referral.UrgentSince,
                 Status = referral.Status,
                 AssignedTo = referral.AssignedTo,

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220425085539_AddPrimarySupportReasonToReferral.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220425085539_AddPrimarySupportReasonToReferral.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using BrokerageApi.V1.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using NpgsqlTypes;
@@ -11,9 +12,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220425085539_AddPrimarySupportReasonToReferral")]
+    partial class AddPrimarySupportReasonToReferral
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220425085539_AddPrimarySupportReasonToReferral.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220425085539_AddPrimarySupportReasonToReferral.cs
@@ -1,0 +1,23 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddPrimarySupportReasonToReferral : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "primary_support_reason",
+                table: "referrals",
+                type: "text",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "primary_support_reason",
+                table: "referrals");
+        }
+    }
+}

--- a/BrokerageApi/V1/Infrastructure/Referral.cs
+++ b/BrokerageApi/V1/Infrastructure/Referral.cs
@@ -22,6 +22,8 @@ namespace BrokerageApi.V1.Infrastructure
         [Required]
         public string ResidentName { get; set; }
 
+        public string PrimarySupportReason { get; set; }
+
         public DateTime? UrgentSince { get; set; }
 
         public string AssignedTo { get; set; }


### PR DESCRIPTION
Whilst the PSR isn't displayed in the Kanban board, it does control the CEDAR cost centre code so we should capture it for later use.
