### PR TITLE
Fbt 208 fix end cancel

### DIFF
--- a/BrokerageApi.Tests/V1/E2ETests/ElementsTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/ElementsTests.cs
@@ -161,9 +161,9 @@ namespace BrokerageApi.Tests.V1.E2ETests
 
             code.Should().Be(HttpStatusCode.OK);
 
-            var resultElement = await Context.Elements.SingleAsync(e => e.Id == element.Id);
-            resultElement.EndDate.Should().Be(request.EndDate);
-            resultElement.UpdatedAt.Should().Be(CurrentInstant);
+            var resultReferralElement = await Context.ReferralElements.SingleAsync(re => re.ElementId == element.Id && re.ReferralId == referral.Id);
+            resultReferralElement.PendingEndDate.Should().Be(request.EndDate);
+            resultReferralElement.PendingComment.Should().Be(request.Comment);
 
             var auditEvent = await Context.AuditEvents.SingleOrDefaultAsync(ae => ae.EventType == AuditEventType.ElementEnded);
             auditEvent.Should().NotBeNull();
@@ -203,9 +203,9 @@ namespace BrokerageApi.Tests.V1.E2ETests
 
             code.Should().Be(HttpStatusCode.OK);
 
-            var resultElement = await Context.Elements.SingleAsync(e => e.Id == element.Id);
-            resultElement.InternalStatus.Should().Be(ElementStatus.Cancelled);
-            resultElement.UpdatedAt.Should().Be(CurrentInstant);
+            var resultReferralElement = await Context.ReferralElements.SingleAsync(re => re.ElementId == element.Id && re.ReferralId == referral.Id);
+            resultReferralElement.PendingCancellation.Should().BeTrue();
+            resultReferralElement.PendingComment.Should().Be(request.Comment);
 
             var auditEvent = await Context.AuditEvents.SingleOrDefaultAsync(ae => ae.EventType == AuditEventType.ElementCancelled);
             auditEvent.Should().NotBeNull();

--- a/BrokerageApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/BrokerageApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -63,6 +63,7 @@ namespace BrokerageApi.Tests.V1.Factories
         [Test]
         public void ElementMapsCorrectly()
         {
+            var expectedReferralId = 1234;
             var grandParentElement = _fixture.Build<Element>()
                 .With(e => e.InternalStatus, ElementStatus.InProgress)
                 .Create();
@@ -81,8 +82,14 @@ namespace BrokerageApi.Tests.V1.Factories
                 .With(e => e.ParentElementId, parentElement.Id)
                 .With(e => e.SuspensionElements, suspensionElements.ToList)
                 .Create();
+            var expectedReferralElement = _fixture.BuildReferralElement(expectedReferralId, element.Id).Create();
+            element.ReferralElements = new List<ReferralElement>
+            {
+                expectedReferralElement,
+                _fixture.BuildReferralElement(expectedReferralId + 1, element.Id).Create()
+            };
 
-            var response = element.ToResponse();
+            var response = element.ToResponse(expectedReferralId);
 
             response.Id.Should().Be(element.Id);
             response.ElementType.Should().BeEquivalentTo(element.ElementType?.ToResponse());
@@ -104,10 +111,14 @@ namespace BrokerageApi.Tests.V1.Factories
             response.CreatedBy.Should().Be(element.CreatedBy);
             response.CreatedAt.Should().Be(element.CreatedAt);
             response.UpdatedAt.Should().Be(element.UpdatedAt);
-            response.ParentElement.Should().BeEquivalentTo(parentElement.ToResponse(false));
+            response.ParentElement.Should().BeEquivalentTo(parentElement.ToResponse(expectedReferralId, false));
             response.ParentElement.ParentElement.Should().BeNull();
             response.SuspensionElements.Should().BeEquivalentTo(suspensionElements.Select(e => e.ToResponse()));
             response.Comment.Should().Be(element.Comment);
+            response.PendingEndDate.Should().Be(expectedReferralElement.PendingEndDate);
+            response.PendingCancellation.Should().Be(expectedReferralElement.PendingCancellation);
+            response.PendingComment.Should().Be(expectedReferralElement.PendingComment);
+
         }
     }
 }

--- a/BrokerageApi/V1/Boundary/Response/ElementResponse.cs
+++ b/BrokerageApi/V1/Boundary/Response/ElementResponse.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using Newtonsoft.Json;
 using NodaTime;
 using BrokerageApi.V1.Infrastructure;
+using JetBrains.Annotations;
 
 namespace BrokerageApi.V1.Boundary.Response
 {
@@ -24,6 +25,11 @@ namespace BrokerageApi.V1.Boundary.Response
         public ElementResponse ParentElement { get; set; }
         public List<ElementResponse> SuspensionElements { get; set; }
         public string CreatedBy { get; set; }
+
+        public LocalDate? PendingEndDate { get; set; }
+        public bool? PendingCancellation { get; set; }
+        [CanBeNull]
+        public string PendingComment { get; set; }
 
         public LocalDate StartDate { get; set; }
 

--- a/BrokerageApi/V1/Controllers/CarePackagesController.cs
+++ b/BrokerageApi/V1/Controllers/CarePackagesController.cs
@@ -40,7 +40,7 @@ namespace BrokerageApi.V1.Controllers
 
         [Authorize]
         [HttpGet]
-        [ProducesResponseType(typeof(ReferralResponse), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(CarePackageResponse), StatusCodes.Status200OK)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status404NotFound)]
         [ProducesResponseType(typeof(ProblemDetails), StatusCodes.Status500InternalServerError)]
         public async Task<IActionResult> GetCarePackage([FromRoute] int referralId)

--- a/BrokerageApi/V1/Factories/ResponseFactory.cs
+++ b/BrokerageApi/V1/Factories/ResponseFactory.cs
@@ -30,13 +30,15 @@ namespace BrokerageApi.V1.Factories
                 StartDate = carePackage.StartDate,
                 WeeklyCost = carePackage.WeeklyCost,
                 WeeklyPayment = carePackage.WeeklyPayment,
-                Elements = carePackage.Elements.Select(e => e.ToResponse()).ToList(),
+                Elements = carePackage.ReferralElements.Select(re => re.Element.ToResponse(re.ReferralId)).ToList(),
                 Comment = carePackage.Comment
             };
         }
 
-        public static ElementResponse ToResponse(this Element element, bool includeParent = true)
+        public static ElementResponse ToResponse(this Element element, int? referralId = null, bool includeParent = true)
         {
+            var referralElement = referralId.HasValue ? element.ReferralElements?.SingleOrDefault(re => re.ReferralId == referralId) : null;
+
             return new ElementResponse
             {
                 Id = element.Id,
@@ -59,9 +61,12 @@ namespace BrokerageApi.V1.Factories
                 CreatedBy = element.CreatedBy,
                 CreatedAt = element.CreatedAt,
                 UpdatedAt = element.UpdatedAt,
-                ParentElement = includeParent ? element.ParentElement?.ToResponse(false) : null,
+                ParentElement = includeParent ? element.ParentElement?.ToResponse(referralId, false) : null,
                 SuspensionElements = element.SuspensionElements?.Select(e => e.ToResponse()).ToList(),
-                Comment = element.Comment
+                Comment = element.Comment,
+                PendingEndDate = referralElement?.PendingEndDate,
+                PendingCancellation = referralElement?.PendingCancellation,
+                PendingComment = referralElement?.PendingComment
             };
         }
 

--- a/BrokerageApi/V1/Gateways/ElementGateway.cs
+++ b/BrokerageApi/V1/Gateways/ElementGateway.cs
@@ -40,6 +40,7 @@ namespace BrokerageApi.V1.Gateways
         {
             return await _currentElements
                 .Where(e => e.Id == id)
+                .Include(e => e.ReferralElements)
                 .SingleOrDefaultAsync();
         }
 

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220608122943_AddReferralElementsPendingColumns.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220608122943_AddReferralElementsPendingColumns.Designer.cs
@@ -5,6 +5,7 @@ using BrokerageApi.V1.Infrastructure;
 using BrokerageApi.V1.Infrastructure.AuditEvents;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -13,9 +14,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220608122943_AddReferralElementsPendingColumns")]
+    partial class AddReferralElementsPendingColumns
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220608122943_AddReferralElementsPendingColumns.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220608122943_AddReferralElementsPendingColumns.cs
@@ -1,0 +1,44 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+using NodaTime;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddReferralElementsPendingColumns : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "pending_cancellation",
+                table: "referral_elements",
+                type: "boolean",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "pending_comment",
+                table: "referral_elements",
+                type: "text",
+                nullable: true);
+
+            migrationBuilder.AddColumn<LocalDate>(
+                name: "pending_end_date",
+                table: "referral_elements",
+                type: "date",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "pending_cancellation",
+                table: "referral_elements");
+
+            migrationBuilder.DropColumn(
+                name: "pending_comment",
+                table: "referral_elements");
+
+            migrationBuilder.DropColumn(
+                name: "pending_end_date",
+                table: "referral_elements");
+        }
+    }
+}

--- a/BrokerageApi/V1/Infrastructure/ReferralElement.cs
+++ b/BrokerageApi/V1/Infrastructure/ReferralElement.cs
@@ -1,3 +1,6 @@
+using JetBrains.Annotations;
+using NodaTime;
+
 namespace BrokerageApi.V1.Infrastructure
 {
     public class ReferralElement
@@ -8,5 +11,9 @@ namespace BrokerageApi.V1.Infrastructure
 
         public int ElementId { get; set; }
         public Element Element { get; set; }
+        public LocalDate? PendingEndDate { get; set; }
+        public bool? PendingCancellation { get; set; }
+        [CanBeNull]
+        public string PendingComment { get; set; }
     }
 }

--- a/BrokerageApi/V1/UseCase/CarePackageElements/CancelElementUseCase.cs
+++ b/BrokerageApi/V1/UseCase/CarePackageElements/CancelElementUseCase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using BrokerageApi.V1.Gateways.Interfaces;
 using BrokerageApi.V1.Infrastructure;
@@ -55,9 +56,10 @@ namespace BrokerageApi.V1.UseCase.CarePackageElements
                 throw new InvalidOperationException($"Element {element.Id} is not approved");
             }
 
-            element.InternalStatus = ElementStatus.Cancelled;
-            element.UpdatedAt = _clockService.Now;
-            element.Comment = comment;
+            var referralElement = element.ReferralElements.Single(re => re.ElementId == element.Id);
+            referralElement.PendingCancellation = true;
+            referralElement.PendingComment = comment;
+
             await _dbSaver.SaveChangesAsync();
 
             var metadata = new ElementAuditEventMetadata

--- a/BrokerageApi/V1/UseCase/CarePackageElements/EndElementUseCase.cs
+++ b/BrokerageApi/V1/UseCase/CarePackageElements/EndElementUseCase.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using BrokerageApi.V1.Gateways.Interfaces;
 using BrokerageApi.V1.Infrastructure;
@@ -61,9 +62,10 @@ namespace BrokerageApi.V1.UseCase.CarePackageElements
                 throw new ArgumentException($"Element {element.Id} has an end date before the requested end date");
             }
 
-            element.EndDate = endDate;
-            element.UpdatedAt = _clockService.Now;
-            element.Comment = comment;
+            var referralElement = element.ReferralElements.Single(re => re.ReferralId == referral.Id);
+            referralElement.PendingEndDate = endDate;
+            referralElement.PendingComment = comment;
+
             await _dbSaver.SaveChangesAsync();
 
             var metadata = new ElementAuditEventMetadata

--- a/BrokerageApi/V1/UseCase/CarePackages/EndCarePackageUseCase.cs
+++ b/BrokerageApi/V1/UseCase/CarePackages/EndCarePackageUseCase.cs
@@ -45,7 +45,7 @@ namespace BrokerageApi.V1.UseCase.CarePackages
 
             foreach (var element in referral.Elements)
             {
-                await _endElementUseCase.ExecuteAsync(referral.Id, element.Id, endDate, null);
+                await _endElementUseCase.ExecuteAsync(referral.Id, element.Id, endDate, comment);
             }
 
             referral.UpdatedAt = _clockService.Now;


### PR DESCRIPTION
End and Cancel element no longer modify the elements but use the new fields on the referral_element table.

Return these new fields in the ElementResonse object wherever that is returned (GetCarePackage etc)