### PR TITLE
Test speedup

### DIFF
--- a/BrokerageApi.Tests/V1/Controllers/AuditControllerTests.cs
+++ b/BrokerageApi.Tests/V1/Controllers/AuditControllerTests.cs
@@ -52,7 +52,7 @@ namespace BrokerageApi.Tests.V1.Controllers
                 Status = ReferralStatus.Approved
             };
 
-            var auditEvents = _fixture.Build<AuditEvent>()
+            var auditEvents = _fixture.BuildAuditEvent()
                 .With(ae => ae.SocialCareId, socialCareId)
                 .With(ae => ae.Metadata, "{ \"referralId\": 1234 }")
                 .With(ae => ae.Referral, referral)

--- a/BrokerageApi.Tests/V1/Controllers/AuditControllerTests.cs
+++ b/BrokerageApi.Tests/V1/Controllers/AuditControllerTests.cs
@@ -48,7 +48,7 @@ namespace BrokerageApi.Tests.V1.Controllers
                 ResidentName = "A Service User",
                 PrimarySupportReason = "Physical Support",
                 DirectPayments = "No",
-                AssignedBroker = "a.broker@hackney.gov.uk",
+                AssignedBrokerEmail = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
 

--- a/BrokerageApi.Tests/V1/Controllers/CarePackageElementsControllerTests.cs
+++ b/BrokerageApi.Tests/V1/Controllers/CarePackageElementsControllerTests.cs
@@ -64,8 +64,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task CreatesElement()
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .Create();
 
@@ -109,8 +108,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task CreateElementMapsErrors(Exception exception, HttpStatusCode expectedStatusCode)
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .Create();
 
@@ -133,9 +131,10 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task DeletesElement()
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var elements = _fixture.BuildElement(1, 1).CreateMany();
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
+                .With(x => x.Elements, elements.ToList)
                 .Create();
             var elementId = referral.Elements.First().Id;
 
@@ -168,8 +167,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task DeleteElementMapsErrors(Exception exception, int expectedStatusCode)
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .Create();
 
@@ -178,7 +176,7 @@ namespace BrokerageApi.Tests.V1.Controllers
                 .Throws(exception);
 
             // Act
-            var objectResult = await _classUnderTest.DeleteElement(referral.Id, referral.Elements.First().Id);
+            var objectResult = await _classUnderTest.DeleteElement(referral.Id, 1);
             var statusCode = GetStatusCode(objectResult);
 
             // Assert
@@ -280,8 +278,7 @@ namespace BrokerageApi.Tests.V1.Controllers
             var element = _fixture.BuildElement(1, 1)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .With(x => x.Elements, new List<Element> { element })
                 .Create();
@@ -309,8 +306,7 @@ namespace BrokerageApi.Tests.V1.Controllers
             var element = _fixture.BuildElement(1, 1)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .With(x => x.Elements, new List<Element> { element })
                 .Create();

--- a/BrokerageApi.Tests/V1/Controllers/CarePackagesControllerTests.cs
+++ b/BrokerageApi.Tests/V1/Controllers/CarePackagesControllerTests.cs
@@ -103,8 +103,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task StartCarePackage()
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .Create();
 
@@ -144,8 +143,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task StartCarePackageWhenReferralIsUnassigned()
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Unassigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Unassigned)
                 .Create();
 
             _mockStartCarePackageUseCase
@@ -165,8 +163,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task StartCarePackageWhenReferralIsAssignedToSomeoneElse()
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "other.broker@hackney.gov.uk")
                 .Create();
 
@@ -295,7 +292,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task CanGetBudgetApprovers()
         {
             const int referralId = 1234;
-            var expectedApprovers = _fixture.CreateMany<User>();
+            var expectedApprovers = _fixture.BuildUser().CreateMany();
             const decimal expectedEstimatedYearlyCost = 12345678;
 
             _mockGetBudgetApproversUseCase

--- a/BrokerageApi.Tests/V1/Controllers/ReferralsControllerTests.cs
+++ b/BrokerageApi.Tests/V1/Controllers/ReferralsControllerTests.cs
@@ -68,7 +68,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         {
             // Arrange
             var request = _fixture.Create<CreateReferralRequest>();
-            var referral = _fixture.Create<Referral>();
+            var referral = _fixture.BuildReferral().Create();
 
             _mockCreateReferralUseCase
                 .Setup(x => x.ExecuteAsync(request))
@@ -88,7 +88,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetCurrentReferrals()
         {
             // Arrange
-            var referrals = _fixture.CreateMany<Referral>();
+            var referrals = _fixture.BuildReferral().CreateMany();
             _mockGetCurrentReferralsUseCase
                 .Setup(x => x.ExecuteAsync(null))
                 .ReturnsAsync(referrals);
@@ -107,7 +107,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetFilteredCurrentReferrals()
         {
             // Arrange
-            var referrals = _fixture.CreateMany<Referral>();
+            var referrals = _fixture.BuildReferral().CreateMany();
             _mockGetCurrentReferralsUseCase
                 .Setup(x => x.ExecuteAsync(ReferralStatus.Unassigned))
                 .ReturnsAsync(referrals);
@@ -126,7 +126,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetAssignedReferrals()
         {
             // Arrange
-            var referrals = _fixture.CreateMany<Referral>();
+            var referrals = _fixture.BuildReferral().CreateMany();
             _mockGetAssignedReferralsUseCase
                 .Setup(x => x.ExecuteAsync(null))
                 .ReturnsAsync(referrals);
@@ -145,7 +145,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetFilteredAssignedReferrals()
         {
             // Arrange
-            var referrals = _fixture.CreateMany<Referral>();
+            var referrals = _fixture.BuildReferral().CreateMany();
             _mockGetAssignedReferralsUseCase
                 .Setup(x => x.ExecuteAsync(ReferralStatus.InProgress))
                 .ReturnsAsync(referrals);
@@ -164,7 +164,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetReferral()
         {
             // Arrange
-            var referral = _fixture.Create<Referral>();
+            var referral = _fixture.BuildReferral().Create();
             _mockGetReferralByIdUseCase
                 .Setup(x => x.ExecuteAsync(referral.Id))
                 .ReturnsAsync(referral);
@@ -205,8 +205,7 @@ namespace BrokerageApi.Tests.V1.Controllers
                 .With(x => x.Broker, "a.broker@hackney.gov.uk")
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .Create();
 
             _mockAssignBrokerToReferralUseCase
@@ -253,8 +252,7 @@ namespace BrokerageApi.Tests.V1.Controllers
                 .With(x => x.Broker, "a.broker@hackney.gov.uk")
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .Create();
 
             _mockAssignBrokerToReferralUseCase
@@ -278,8 +276,7 @@ namespace BrokerageApi.Tests.V1.Controllers
                 .With(x => x.Broker, "a.broker@hackney.gov.uk")
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .Create();
 
             _mockReassignBrokerToReferralUseCase
@@ -326,8 +323,7 @@ namespace BrokerageApi.Tests.V1.Controllers
                 .With(x => x.Broker, "a.broker@hackney.gov.uk")
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Unassigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Unassigned)
                 .Create();
 
             _mockReassignBrokerToReferralUseCase

--- a/BrokerageApi.Tests/V1/Controllers/ServicesControllerTests.cs
+++ b/BrokerageApi.Tests/V1/Controllers/ServicesControllerTests.cs
@@ -51,7 +51,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetAllServices()
         {
             // Arrange
-            var services = _fixture.CreateMany<Service>();
+            var services = _fixture.BuildService().CreateMany();
             _mockGetAllServicesUseCase
                 .Setup(x => x.ExecuteAsync())
                 .ReturnsAsync(services);
@@ -70,7 +70,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetService()
         {
             // Arrange
-            var service = _fixture.Create<Service>();
+            var service = _fixture.BuildService().Create();
             _mockGetServiceByIdUseCase
                 .Setup(x => x.ExecuteAsync(service.Id))
                 .ReturnsAsync(service);
@@ -107,8 +107,8 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task FindProvidersByService()
         {
             // Arrange
-            var service = _fixture.Create<Service>();
-            var providers = _fixture.CreateMany<Provider>();
+            var service = _fixture.BuildService().Create();
+            var providers = _fixture.BuildProvider().CreateMany();
             _mockFindProvidersByServiceUseCase
                 .Setup(x => x.ExecuteAsync(service.Id, "Acme"))
                 .ReturnsAsync(providers);

--- a/BrokerageApi.Tests/V1/Controllers/UsersControllerTests.cs
+++ b/BrokerageApi.Tests/V1/Controllers/UsersControllerTests.cs
@@ -48,7 +48,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetAllUsers()
         {
             // Arrange
-            var users = _fixture.CreateMany<User>();
+            var users = _fixture.BuildUser().CreateMany();
             _mockGetAllUsersUseCase
                 .Setup(x => x.ExecuteAsync(null))
                 .ReturnsAsync(users);
@@ -67,7 +67,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetFilteredAllUsers()
         {
             // Arrange
-            var users = _fixture.CreateMany<User>();
+            var users = _fixture.BuildUser().CreateMany();
             _mockGetAllUsersUseCase
                 .Setup(x => x.ExecuteAsync(UserRole.Broker))
                 .ReturnsAsync(users);
@@ -86,7 +86,7 @@ namespace BrokerageApi.Tests.V1.Controllers
         public async Task GetCurrentUser()
         {
             // Arrange
-            var user = _fixture.Create<User>();
+            var user = _fixture.BuildUser().Create();
             _mockCurrentUserUseCase
                 .Setup(x => x.ExecuteAsync())
                 .ReturnsAsync(user);

--- a/BrokerageApi.Tests/V1/E2ETests/AuditEventTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/AuditEventTests.cs
@@ -43,7 +43,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 ResidentName = "A Service User",
                 PrimarySupportReason = "Physical Support",
                 DirectPayments = "No",
-                AssignedBrokerEmail = "a.broker@hackney.gov.uk",
+                AssignedBrokerEmail = ApiUser.Email,
                 Status = ReferralStatus.Approved
             };
 

--- a/BrokerageApi.Tests/V1/E2ETests/AuditEventTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/AuditEventTests.cs
@@ -43,7 +43,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 ResidentName = "A Service User",
                 PrimarySupportReason = "Physical Support",
                 DirectPayments = "No",
-                AssignedBroker = "a.broker@hackney.gov.uk",
+                AssignedBrokerEmail = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
 

--- a/BrokerageApi.Tests/V1/E2ETests/AuditEventTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/AuditEventTests.cs
@@ -47,7 +47,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 Status = ReferralStatus.Approved
             };
 
-            var auditEvents = _fixture.Build<AuditEvent>()
+            var auditEvents = _fixture.BuildAuditEvent()
                 .With(ae => ae.UserId, user.Id)
                 .With(ae => ae.SocialCareId, socialCareId)
                 .Without(ae => ae.User)

--- a/BrokerageApi.Tests/V1/Factories/ResponseFactoryTest.cs
+++ b/BrokerageApi.Tests/V1/Factories/ResponseFactoryTest.cs
@@ -28,9 +28,9 @@ namespace BrokerageApi.Tests.V1.Factories
         [Test]
         public void AuditResponseMapsCorrectly()
         {
-            var referral = _fixture.Create<Referral>();
+            var referral = _fixture.BuildReferral().Create();
 
-            var auditEvent = _fixture.Build<AuditEvent>()
+            var auditEvent = _fixture.BuildAuditEvent()
                 .With(ae => ae.Metadata, "{ \"test\": \"test\" }")
                 .With(ae => ae.Referral, referral)
                 .Create();

--- a/BrokerageApi.Tests/V1/Gateways/AuditGatewayTests.cs
+++ b/BrokerageApi.Tests/V1/Gateways/AuditGatewayTests.cs
@@ -166,7 +166,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 ResidentName = "A Service User",
                 PrimarySupportReason = "Physical Support",
                 DirectPayments = "No",
-                AssignedBroker = "a.broker@hackney.gov.uk",
+                AssignedBrokerEmail = "a.broker@hackney.gov.uk",
                 Status = ReferralStatus.Approved
             };
 

--- a/BrokerageApi.Tests/V1/Gateways/AuditGatewayTests.cs
+++ b/BrokerageApi.Tests/V1/Gateways/AuditGatewayTests.cs
@@ -68,8 +68,8 @@ namespace BrokerageApi.Tests.V1.Gateways
         [TestCaseSource(nameof(_metadataTests))]
         public async Task ReferralBrokerAssignmentHasCorrectMetadata(AuditEventType eventType, string expectedMessage, AuditMetadataBase metadata)
         {
-            var expectedReferral = await SeedReferral();
             var expectedUser = await SeedUser();
+            var expectedReferral = await SeedReferral(expectedUser);
             const string expectedSocialCareId = "socialCareId";
 
             await _classUnderTest.AddAuditEvent(eventType, "socialCareId", expectedUser.Id, metadata);
@@ -154,7 +154,7 @@ namespace BrokerageApi.Tests.V1.Gateways
             return auditEvents;
         }
 
-        private async Task<Referral> SeedReferral()
+        private async Task<Referral> SeedReferral(User expectedUser)
         {
             var referral = new Referral()
             {
@@ -166,7 +166,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 ResidentName = "A Service User",
                 PrimarySupportReason = "Physical Support",
                 DirectPayments = "No",
-                AssignedBrokerEmail = "a.broker@hackney.gov.uk",
+                AssignedBrokerEmail = expectedUser.Email,
                 Status = ReferralStatus.Approved
             };
 

--- a/BrokerageApi.Tests/V1/Gateways/AuditGatewayTests.cs
+++ b/BrokerageApi.Tests/V1/Gateways/AuditGatewayTests.cs
@@ -140,7 +140,7 @@ namespace BrokerageApi.Tests.V1.Gateways
 
         private async Task<IEnumerable<AuditEvent>> SeedEvents(int expectedUserId, string expectedSocialCareId, int count = 5)
         {
-            var auditEvents = _fixture.Build<AuditEvent>()
+            var auditEvents = _fixture.BuildAuditEvent()
                 .With(ae => ae.UserId, expectedUserId)
                 .With(ae => ae.SocialCareId, expectedSocialCareId)
                 .Without(ae => ae.Metadata)

--- a/BrokerageApi.Tests/V1/UseCase/AssignBrokerToReferralUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/AssignBrokerToReferralUseCaseTests.cs
@@ -49,14 +49,13 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task AssignsBrokerToReferral()
         {
             // Arrange
-            var expectedBroker = _fixture.Create<User>();
+            var expectedBroker = _fixture.BuildUser().Create();
 
             var request = _fixture.Build<AssignBrokerRequest>()
                 .With(x => x.Broker, expectedBroker.Email)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Unassigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Unassigned)
                 .Create();
 
             _mockReferralGateway
@@ -112,8 +111,7 @@ namespace BrokerageApi.Tests.V1.UseCase
                 .With(x => x.Broker, expectedBroker)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Unassigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Unassigned)
                 .Create();
 
             _mockReferralGateway
@@ -141,8 +139,7 @@ namespace BrokerageApi.Tests.V1.UseCase
                 .With(x => x.Broker, "a.broker@hackney.gov.uk")
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .Create();
 
             _mockReferralGateway
@@ -162,13 +159,12 @@ namespace BrokerageApi.Tests.V1.UseCase
         {
             // Arrange
             const int expectedUserId = 1234;
-            var expectedBroker = _fixture.Create<User>();
+            var expectedBroker = _fixture.BuildUser().Create();
             var request = _fixture.Build<AssignBrokerRequest>()
                 .With(x => x.Broker, "a.broker@hackney.gov.uk")
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Unassigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Unassigned)
                 .Create();
 
             _mockReferralGateway

--- a/BrokerageApi.Tests/V1/UseCase/CarePackageElements/CreateElementUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackageElements/CreateElementUseCaseTests.cs
@@ -53,12 +53,11 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
         {
             // Arrange
             var currentInstant = SystemClock.Instance.GetCurrentInstant();
-            var elementType = _fixture.Create<ElementType>();
-            var provider = _fixture.Create<Provider>();
+            var elementType = _fixture.BuildElementType(1).Create();
+            var provider = _fixture.BuildProvider().Create();
             const string expectedUserEmail = "expected@email.com";
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.InProgress)
+            var referral = _fixture.BuildReferral(ReferralStatus.InProgress)
                 .With(x => x.AssignedBrokerEmail, expectedUserEmail)
                 .Without(x => x.Elements)
                 .Create();
@@ -135,8 +134,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
             // Arrange
             var request = _fixture.Create<CreateElementRequest>();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.go.uk")
                 .Create();
 
@@ -163,8 +161,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
             // Arrange
             var request = _fixture.Create<CreateElementRequest>();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.InProgress)
+            var referral = _fixture.BuildReferral(ReferralStatus.InProgress)
                 .With(x => x.AssignedBrokerEmail, "other.broker@hackney.gov.uk")
                 .Create();
 
@@ -193,8 +190,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
                 .With(x => x.ElementTypeId, 123456)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.InProgress)
+            var referral = _fixture.BuildReferral(ReferralStatus.InProgress)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .Create();
 
@@ -223,15 +219,14 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
         public void ThrowsArgumentExceptionWhenProviderDoesNotExist()
         {
             // Arrange
-            var elementType = _fixture.Create<ElementType>();
+            var elementType = _fixture.BuildElementType(1).Create();
 
             var request = _fixture.Build<CreateElementRequest>()
                 .With(x => x.ElementTypeId, elementType.Id)
                 .With(x => x.ProviderId, 123456)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.InProgress)
+            var referral = _fixture.BuildReferral(ReferralStatus.InProgress)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .Create();
 
@@ -265,13 +260,12 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
         {
             // Arrange
             var currentInstant = SystemClock.Instance.GetCurrentInstant();
-            var elementType = _fixture.Create<ElementType>();
-            var provider = _fixture.Create<Provider>();
+            var elementType = _fixture.BuildElementType(1).Create();
+            var provider = _fixture.BuildProvider().Create();
 
             var parentElement = _fixture.BuildElement(provider.Id, elementType.Id).Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.InProgress)
+            var referral = _fixture.BuildReferral(ReferralStatus.InProgress)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .With(x => x.Elements, new List<Element> { parentElement })
                 .Create();

--- a/BrokerageApi.Tests/V1/UseCase/CarePackageElements/DeleteElementUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackageElements/DeleteElementUseCaseTests.cs
@@ -176,8 +176,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
 
         private Referral CreateReferral(ReferralStatus referralStatus = ReferralStatus.InProgress, List<Element> elements = null, string assignedToCom = null)
         {
-            var referralBuilder = _fixture.Build<Referral>()
-                .With(r => r.Status, referralStatus)
+            var referralBuilder = _fixture.BuildReferral(referralStatus)
                 .With(r => r.Elements, elements)
                 .With(r => r.UpdatedAt, _currentInstant.Minus(Duration.FromDays(1)));
 
@@ -195,14 +194,14 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
 
         private IEnumerable<Element> CreateElements(int minId = 0)
         {
-            var elements = _fixture.Build<Element>()
+            var elements = _fixture.BuildElement(1, 1)
                 .With(e => e.Id, _fixture.CreateInt(minId, minId))
                 .CreateMany();
             return elements;
         }
         private Element CreateElement(int elementId)
         {
-            var element = _fixture.Build<Element>()
+            var element = _fixture.BuildElement(1, 1)
                 .With(e => e.Id, elementId)
                 .Create();
             return element;

--- a/BrokerageApi.Tests/V1/UseCase/CarePackageElements/EditElementUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackageElements/EditElementUseCaseTests.cs
@@ -273,17 +273,16 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
         private (Provider provider, ElementType elementType, Element element, Referral referral) CreateReferralWithElement(ReferralStatus referralStatus = ReferralStatus.InProgress)
         {
 
-            var elementType = _fixture
-                .Create<ElementType>();
+            var elementType = _fixture.BuildElementType(1)
+                .Create();
 
-            var provider = _fixture
-                .Create<Provider>();
+            var provider = _fixture.BuildProvider()
+                .Create();
 
             var element = _fixture.BuildElement(provider.Id, elementType.Id)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, referralStatus)
+            var referral = _fixture.BuildReferral(referralStatus)
                 .With(x => x.Elements, new List<Element> { element })
                 .Create();
 

--- a/BrokerageApi.Tests/V1/UseCase/CarePackages/AssignBudgetApproverToCarePackageUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackages/AssignBudgetApproverToCarePackageUseCaseTests.cs
@@ -94,7 +94,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackages
             await _classUnderTest.ExecuteAsync(referral.Id, approverEmail);
 
             referral.Status.Should().Be(ReferralStatus.AwaitingApproval);
-            referral.AssignedBrokerEmail.Should().BeEquivalentTo(approver.Email);
+            referral.AssignedApproverEmail.Should().BeEquivalentTo(approver.Email);
             _mockDbSaver.VerifyChangesSaved();
         }
 

--- a/BrokerageApi.Tests/V1/UseCase/CarePackages/GetApproversUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackages/GetApproversUseCaseTests.cs
@@ -38,10 +38,10 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackages
         public async Task GetApprovers()
         {
             // Arrange
-            var carePackage = _fixture.Build<CarePackage>()
+            var carePackage = _fixture.BuildCarePackage(null, true)
                 .With(c => c.Status, ReferralStatus.InProgress)
                 .Create();
-            var approvers = _fixture.CreateMany<User>();
+            var approvers = _fixture.BuildUser().CreateMany();
             var expectedYearlyCost = (carePackage.WeeklyPayment * 52) +
                                      (carePackage.Elements.Where(e => e.ElementType.CostType == ElementCostType.OneOff).Sum(e => e.Cost));
 
@@ -81,7 +81,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackages
         public async Task ThrowsInvalidOperationExceptionWhenCarePackageIsNotInProgress([Values] ReferralStatus status)
         {
             // Arrange
-            var carePackage = _fixture.Build<CarePackage>()
+            var carePackage = _fixture.BuildCarePackage()
                 .With(c => c.Status, status)
                 .Create();
 
@@ -130,7 +130,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackages
             carePackage.Elements.AddRange(dailyElements);
             carePackage.Elements.AddRange(oneOffElements);
 
-            var approvers = _fixture.CreateMany<User>();
+            var approvers = _fixture.BuildUser().CreateMany();
             var expectedYearlyCost = carePackage.WeeklyPayment * 52 +
                                      oneOffElements.Sum(e => e.Cost);
 

--- a/BrokerageApi.Tests/V1/UseCase/CarePackages/StartCarePackageUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackages/StartCarePackageUseCaseTests.cs
@@ -45,8 +45,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackages
             // Arrange
             var currentInstant = SystemClock.Instance.GetCurrentInstant();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "a.broker@hackney.gov.uk")
                 .Without(x => x.StartedAt)
                 .Create();
@@ -100,8 +99,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackages
         public void ThrowsInvalidOperationExceptionWhenReferralIsUnassigned()
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Unassigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Unassigned)
                 .Create();
 
             _mockReferralGateway
@@ -124,8 +122,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackages
         public void ThrowsUnauthorizedAccessExceptionWhenReferralIsAssignedToSomeoneElse()
         {
             // Arrange
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "other.broker@hackney.gov.uk")
                 .Create();
 

--- a/BrokerageApi.Tests/V1/UseCase/CreateReferralUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CreateReferralUseCaseTests.cs
@@ -30,7 +30,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         {
             // Arrange
             var request = _fixture.Create<CreateReferralRequest>();
-            var referral = _fixture.Create<Referral>();
+            var referral = _fixture.BuildReferral().Create();
 
             _mockReferralGateway
                 .Setup(m => m.CreateAsync(It.IsAny<Referral>()))

--- a/BrokerageApi.Tests/V1/UseCase/FindProvidersByServiceIdUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/FindProvidersByServiceIdUseCaseTests.cs
@@ -34,8 +34,8 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task FindProvidersByService()
         {
             // Arrange
-            var service = _fixture.Create<Service>();
-            var expectedProviders = _fixture.CreateMany<Provider>();
+            var service = _fixture.BuildService().Create();
+            var expectedProviders = _fixture.BuildProvider().CreateMany();
 
             _mockServiceGateway
                 .Setup(x => x.GetByIdAsync(service.Id))

--- a/BrokerageApi.Tests/V1/UseCase/GetAllServicesUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetAllServicesUseCaseTests.cs
@@ -28,7 +28,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetAllServices()
         {
             // Arrange
-            var expectedServices = _fixture.CreateMany<Service>();
+            var expectedServices = _fixture.BuildService().CreateMany();
             _mockServiceGateway
                 .Setup(x => x.GetAllAsync())
                 .ReturnsAsync(expectedServices);
@@ -44,7 +44,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetFilteredAllServices()
         {
             // Arrange
-            var expectedServices = _fixture.CreateMany<Service>();
+            var expectedServices = _fixture.BuildService().CreateMany();
             _mockServiceGateway
                 .Setup(x => x.GetAllAsync())
                 .ReturnsAsync(expectedServices);

--- a/BrokerageApi.Tests/V1/UseCase/GetAllUsersUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetAllUsersUseCaseTests.cs
@@ -28,7 +28,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetAllUsers()
         {
             // Arrange
-            var expectedUsers = _fixture.CreateMany<User>();
+            var expectedUsers = _fixture.BuildUser().CreateMany();
             _mockUserGateway
                 .Setup(x => x.GetAllAsync(null))
                 .ReturnsAsync(expectedUsers);
@@ -44,7 +44,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetFilteredAllUsers()
         {
             // Arrange
-            var expectedUsers = _fixture.CreateMany<User>();
+            var expectedUsers = _fixture.BuildUser().CreateMany();
             _mockUserGateway
                 .Setup(x => x.GetAllAsync(UserRole.BrokerageAssistant))
                 .ReturnsAsync(expectedUsers);

--- a/BrokerageApi.Tests/V1/UseCase/GetAssignedReferralsUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetAssignedReferralsUseCaseTests.cs
@@ -35,7 +35,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetAssignedReferrals()
         {
             // Arrange
-            var expectedReferrals = _fixture.CreateMany<Referral>();
+            var expectedReferrals = _fixture.BuildReferral(ReferralStatus.Assigned).CreateMany();
 
             _mockUserService
                 .SetupGet(x => x.Email)
@@ -56,7 +56,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetFilteredAssignedReferrals()
         {
             // Arrange
-            var expectedReferrals = _fixture.CreateMany<Referral>();
+            var expectedReferrals = _fixture.BuildReferral(ReferralStatus.Assigned).CreateMany();
 
             _mockUserService
                 .SetupGet(x => x.Email)

--- a/BrokerageApi.Tests/V1/UseCase/GetCurrentReferralsUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetCurrentReferralsUseCaseTests.cs
@@ -28,7 +28,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetCurrentReferrals()
         {
             // Arrange
-            var expectedReferrals = _fixture.CreateMany<Referral>();
+            var expectedReferrals = _fixture.BuildReferral().CreateMany();
             _mockReferralGateway
                 .Setup(x => x.GetCurrentAsync(null))
                 .ReturnsAsync(expectedReferrals);
@@ -44,7 +44,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetFilteredCurrentReferrals()
         {
             // Arrange
-            var expectedReferrals = _fixture.CreateMany<Referral>();
+            var expectedReferrals = _fixture.BuildReferral().CreateMany();
             _mockReferralGateway
                 .Setup(x => x.GetCurrentAsync(ReferralStatus.Unassigned))
                 .ReturnsAsync(expectedReferrals);

--- a/BrokerageApi.Tests/V1/UseCase/GetCurrentUserUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetCurrentUserUseCaseTests.cs
@@ -35,7 +35,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         [Test]
         public async Task CanGetCurrentUser()
         {
-            var user = _fixture.Create<User>();
+            var user = _fixture.BuildUser().Create();
 
             _mockUserService.Setup(x => x.Email)
                 .Returns(user.Email);

--- a/BrokerageApi.Tests/V1/UseCase/GetReferralByIdUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetReferralByIdUseCaseTests.cs
@@ -29,7 +29,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetReferral()
         {
             // Arrange
-            var referral = _fixture.Create<Referral>();
+            var referral = _fixture.BuildReferral().Create();
 
             _mockReferralGateway
                 .Setup(x => x.GetByIdAsync(referral.Id))

--- a/BrokerageApi.Tests/V1/UseCase/GetServiceByIdUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetServiceByIdUseCaseTests.cs
@@ -29,7 +29,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task GetService()
         {
             // Arrange
-            var service = _fixture.Create<Service>();
+            var service = _fixture.BuildService().Create();
             _mockServiceGateway
                 .Setup(x => x.GetByIdAsync(service.Id))
                 .ReturnsAsync(service);

--- a/BrokerageApi.Tests/V1/UseCase/GetServiceUserAuditEventsUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/GetServiceUserAuditEventsUseCaseTests.cs
@@ -29,7 +29,7 @@ namespace BrokerageApi.Tests.V1.UseCase
         public void CanGetEvents()
         {
             const string SocialCareId = "socialCareId";
-            var expectedEvents = _fixture.CreateMany<AuditEvent>().AsQueryable().ToPagedList(1, 100);
+            var expectedEvents = _fixture.BuildAuditEvent().CreateMany().AsQueryable().ToPagedList(1, 100);
             _auditGatewayMock.Setup(x => x.GetServiceUserAuditEvents(SocialCareId, It.IsAny<int>(), It.IsAny<int>()))
                 .Returns(expectedEvents);
 

--- a/BrokerageApi.Tests/V1/UseCase/ReassignBrokerToReferralUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/ReassignBrokerToReferralUseCaseTests.cs
@@ -49,14 +49,13 @@ namespace BrokerageApi.Tests.V1.UseCase
         public async Task ReassignsBrokerToReferral()
         {
             // Arrange
-            var expectedBroker = _fixture.Create<User>();
+            var expectedBroker = _fixture.BuildUser().Create();
 
             var request = _fixture.Build<AssignBrokerRequest>()
                 .With(x => x.Broker, expectedBroker.Email)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "other.broker@hackney.gov.uk")
                 .Create();
 
@@ -112,8 +111,7 @@ namespace BrokerageApi.Tests.V1.UseCase
                 .With(x => x.Broker, expectedBroker)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "other.broker@hackney.gov.uk")
                 .Create();
 
@@ -141,8 +139,7 @@ namespace BrokerageApi.Tests.V1.UseCase
                 .With(x => x.Broker, "a.broker@hackney.gov.uk")
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Unassigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Unassigned)
                 .Create();
 
             _mockReferralGateway
@@ -162,13 +159,12 @@ namespace BrokerageApi.Tests.V1.UseCase
         {
             // Arrange
             const int expectedUserId = 1234;
-            var expectedBroker = _fixture.Create<User>();
+            var expectedBroker = _fixture.BuildUser().Create();
             var request = _fixture.Build<AssignBrokerRequest>()
                 .With(x => x.Broker, expectedBroker.Email)
                 .Create();
 
-            var referral = _fixture.Build<Referral>()
-                .With(x => x.Status, ReferralStatus.Assigned)
+            var referral = _fixture.BuildReferral(ReferralStatus.Assigned)
                 .With(x => x.AssignedBrokerEmail, "other.broker@hackney.gov.uk")
                 .Create();
 

--- a/BrokerageApi/V1/UseCase/AssignBudgetApproverToCarePackageUseCase.cs
+++ b/BrokerageApi/V1/UseCase/AssignBudgetApproverToCarePackageUseCase.cs
@@ -66,7 +66,7 @@ namespace BrokerageApi.V1.UseCase
             }
 
             referral.Status = ReferralStatus.AwaitingApproval;
-            referral.AssignedBrokerEmail = approver.Email;
+            referral.AssignedApproverEmail = approver.Email;
 
             await _dbSaver.SaveChangesAsync();
 


### PR DESCRIPTION
Cleanup of all fixture tests that were slow, need to use our custom builders to avoid creating nested objects forever