### PR TITLE
Allow elements without a provider and details

### DIFF
--- a/BrokerageApi.Tests/V1/UseCase/CarePackageElements/CreateElementUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackageElements/CreateElementUseCaseTests.cs
@@ -270,7 +270,6 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
                 .With(x => x.Elements, new List<Element> { parentElement })
                 .Create();
 
-
             var request = _fixture.Build<CreateElementRequest>()
                 .With(x => x.ElementTypeId, elementType.Id)
                 .With(x => x.ProviderId, provider.Id)

--- a/BrokerageApi/V1/Boundary/Request/CreateElementRequest.cs
+++ b/BrokerageApi/V1/Boundary/Request/CreateElementRequest.cs
@@ -10,9 +10,8 @@ namespace BrokerageApi.V1.Boundary.Request
 
         public bool NonPersonalBudget { get; set; }
 
-        public int ProviderId { get; set; }
+        public int? ProviderId { get; set; }
 
-        [Required]
         public string Details { get; set; }
 
         public int? ParentElementId { get; set; }

--- a/BrokerageApi/V1/Boundary/Request/EditElementRequest.cs
+++ b/BrokerageApi/V1/Boundary/Request/EditElementRequest.cs
@@ -10,9 +10,8 @@ namespace BrokerageApi.V1.Boundary.Request
 
         public bool NonPersonalBudget { get; set; }
 
-        public int ProviderId { get; set; }
+        public int? ProviderId { get; set; }
 
-        [Required]
         public string Details { get; set; }
 
         public ElementCost? Monday { get; set; }

--- a/BrokerageApi/V1/Boundary/Response/ElementResponse.cs
+++ b/BrokerageApi/V1/Boundary/Response/ElementResponse.cs
@@ -17,7 +17,6 @@ namespace BrokerageApi.V1.Boundary.Response
 
         public ProviderResponse Provider { get; set; }
 
-        [JsonProperty(Required = Required.DisallowNull)]
         public string Details { get; set; }
 
         public ElementStatus Status { get; set; }

--- a/BrokerageApi/V1/Infrastructure/Element.cs
+++ b/BrokerageApi/V1/Infrastructure/Element.cs
@@ -50,10 +50,9 @@ namespace BrokerageApi.V1.Infrastructure
 
         public bool NonPersonalBudget { get; set; }
 
-        public int ProviderId { get; set; }
+        public int? ProviderId { get; set; }
         public Provider Provider { get; set; }
 
-        [Required]
         public string Details { get; set; }
 
         public ElementStatus InternalStatus { get; set; }

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220615122437_MakeProviderOptional.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220615122437_MakeProviderOptional.Designer.cs
@@ -5,6 +5,7 @@ using BrokerageApi.V1.Infrastructure;
 using BrokerageApi.V1.Infrastructure.AuditEvents;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -13,9 +14,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220615122437_MakeProviderOptional")]
+    partial class MakeProviderOptional
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -109,6 +111,10 @@ namespace V1.Infrastructure.Migrations
                     b.Property<Instant>("CreatedAt")
                         .HasColumnType("timestamp")
                         .HasColumnName("created_at");
+
+                    b.Property<decimal>("EstimatedYearlyCost")
+                        .HasColumnType("numeric")
+                        .HasColumnName("estimated_yearly_cost");
 
                     b.Property<string>("FormName")
                         .IsRequired()

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220615122437_MakeProviderOptional.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220615122437_MakeProviderOptional.cs
@@ -1,0 +1,73 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class MakeProviderOptional : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_elements_providers_provider_id",
+                table: "elements");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "provider_id",
+                table: "elements",
+                type: "integer",
+                nullable: true,
+                oldClrType: typeof(int),
+                oldType: "integer");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "details",
+                table: "elements",
+                type: "text",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "text");
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_elements_providers_provider_id",
+                table: "elements",
+                column: "provider_id",
+                principalTable: "providers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Restrict);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "fk_elements_providers_provider_id",
+                table: "elements");
+
+            migrationBuilder.AlterColumn<int>(
+                name: "provider_id",
+                table: "elements",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0,
+                oldClrType: typeof(int),
+                oldType: "integer",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<string>(
+                name: "details",
+                table: "elements",
+                type: "text",
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "text",
+                oldNullable: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "fk_elements_providers_provider_id",
+                table: "elements",
+                column: "provider_id",
+                principalTable: "providers",
+                principalColumn: "id",
+                onDelete: ReferentialAction.Cascade);
+        }
+    }
+}

--- a/BrokerageApi/V1/UseCase/CarePackageElements/CreateElementUseCase.cs
+++ b/BrokerageApi/V1/UseCase/CarePackageElements/CreateElementUseCase.cs
@@ -63,11 +63,16 @@ namespace BrokerageApi.V1.UseCase.CarePackageElements
                 throw new ArgumentException($"Element type not found for: {request.ElementTypeId}");
             }
 
-            var provider = await _providerGateway.GetByIdAsync(request.ProviderId);
+            var provider = (Provider) null;
 
-            if (provider is null)
+            if (request.ProviderId != null)
             {
-                throw new ArgumentException($"Provider not found for: {request.ProviderId}");
+                provider = await _providerGateway.GetByIdAsync((int) request.ProviderId);
+
+                if (provider is null)
+                {
+                    throw new ArgumentException($"Provider not found for: {request.ProviderId}");
+                }
             }
 
             var timeNow = _clock.Now;

--- a/BrokerageApi/V1/UseCase/CarePackageElements/EditElementUseCase.cs
+++ b/BrokerageApi/V1/UseCase/CarePackageElements/EditElementUseCase.cs
@@ -68,14 +68,21 @@ namespace BrokerageApi.V1.UseCase.CarePackageElements
                 throw new ArgumentException($"Element type not found for: {request.ElementTypeId}");
             }
 
-            var provider = await _providerGateway.GetByIdAsync(request.ProviderId);
+            var provider = (Provider) null;
 
-            if (provider is null)
+            if (request.ProviderId != null)
             {
-                throw new ArgumentException($"Provider not found for: {request.ProviderId}");
+                provider = await _providerGateway.GetByIdAsync((int) request.ProviderId);
+
+                if (provider is null)
+                {
+                    throw new ArgumentException($"Provider not found for: {request.ProviderId}");
+                }
             }
 
             request.ToDatabase(element);
+            element.ElementType = elementType;
+            element.Provider = provider;
             element.UpdatedAt = _clockService.Now;
             referral.UpdatedAt = _clockService.Now;
 


### PR DESCRIPTION
Some elements such as suspensions don't have a provider and details so make these fields optional when creating/editing in-progress elements.
