### PR TITLE
Added new migration to reflect changes in FluentAPI

### DIFF
--- a/BrokerageApi/V1/Infrastructure/Migrations/20220712090826_BrokerageContextLatestChanges.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220712090826_BrokerageContextLatestChanges.Designer.cs
@@ -5,6 +5,7 @@ using BrokerageApi.V1.Infrastructure;
 using BrokerageApi.V1.Infrastructure.AuditEvents;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -15,9 +16,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220712090826_BrokerageContextLatestChanges")]
+    partial class BrokerageContextLatestChanges
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220712090826_BrokerageContextLatestChanges.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220712090826_BrokerageContextLatestChanges.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Microsoft.EntityFrameworkCore.Migrations;
 using NpgsqlTypes;
 

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220712090826_BrokerageContextLatestChanges.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220712090826_BrokerageContextLatestChanges.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using NpgsqlTypes;
+
+#nullable disable
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class BrokerageContextLatestChanges : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<NpgsqlTsVector>(
+                name: "name_search_vector",
+                table: "service_users",
+                type: "tsvector",
+                nullable: true,
+                oldClrType: typeof(NpgsqlTsVector),
+                oldType: "tsvector",
+                oldNullable: true)
+                .Annotation("Npgsql:TsVectorConfig", "simple")
+                .Annotation("Npgsql:TsVectorProperties", new[] { "service_user_name" });
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<NpgsqlTsVector>(
+                name: "name_search_vector",
+                table: "service_users",
+                type: "tsvector",
+                nullable: true,
+                oldClrType: typeof(NpgsqlTsVector),
+                oldType: "tsvector",
+                oldNullable: true)
+                .OldAnnotation("Npgsql:TsVectorConfig", "simple")
+                .OldAnnotation("Npgsql:TsVectorProperties", new[] { "service_user_name" });
+        }
+    }
+}


### PR DESCRIPTION
When the NameSearchVector column was added to the ServiceUser table, the BrokerageContext was unchanged.
This created problems when the new column had to be automatically populated as the relationship was not present.
Once the change was reflected in the context, no further migrations were created. This migration fixes the issue.