### PR TITLE
Configure what elements included in weekly cost/payments by type

### DIFF
--- a/BrokerageApi.Tests/V1/E2ETests/CarePackageCareChargesTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/CarePackageCareChargesTests.cs
@@ -310,7 +310,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             resetCode.Should().Be(HttpStatusCode.OK);
 
             var resetReferralElement = await Context.ReferralElements.SingleAsync(re => re.ElementId == element.Id && re.ReferralId == referral.Id);
-            resetReferralElement.PendingCancellation.Should().BeNull();
+            resetReferralElement.PendingCancellation.Should().BeFalse();
             resetReferralElement.PendingComment.Should().BeNull();
         }
 

--- a/BrokerageApi.Tests/V1/E2ETests/CarePackageElementsTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/CarePackageElementsTests.cs
@@ -486,7 +486,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
             resetCode.Should().Be(HttpStatusCode.OK);
 
             var resetReferralElement = await Context.ReferralElements.SingleAsync(re => re.ElementId == element.Id && re.ReferralId == referral.Id);
-            resetReferralElement.PendingCancellation.Should().BeNull();
+            resetReferralElement.PendingCancellation.Should().BeFalse();
             resetReferralElement.PendingComment.Should().BeNull();
         }
 

--- a/BrokerageApi.Tests/V1/E2ETests/CarePackageTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/CarePackageTests.cs
@@ -107,9 +107,9 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 ParentElementId = null,
                 StartDate = startDate,
                 EndDate = null,
-                Wednesday = new ElementCost(1, -100),
+                Wednesday = new ElementCost(1, 100),
                 Quantity = 1,
-                Cost = -100,
+                Cost = 100,
                 CreatedAt = CurrentInstant,
                 UpdatedAt = CurrentInstant,
                 ParentElement = parentElement
@@ -164,8 +164,8 @@ namespace BrokerageApi.Tests.V1.E2ETests
 
             response.Id.Should().Be(referral.Id);
             response.StartDate.Should().Be(previousStartDate);
-            response.WeeklyCost.Should().Be(225);
-            response.WeeklyPayment.Should().Be(125);
+            response.WeeklyCost.Should().Be(325);
+            response.WeeklyPayment.Should().Be(325);
             response.Elements.Should().HaveCount(3);
 
             var responseElement1 = response.Elements.Single(e => e.Id == element1.Id);
@@ -546,6 +546,8 @@ namespace BrokerageApi.Tests.V1.E2ETests
 
             var oneOffElementType = _fixture.BuildElementType(service.Id)
                 .With(et => et.CostType, ElementCostType.OneOff)
+                .With(et => et.CostOperation, MathOperation.Ignore)
+                .With(et => et.PaymentOperation, MathOperation.Ignore)
                 .Create();
 
             var dailyElements = _fixture.BuildElement(dailyElementType.Id, provider.Id)
@@ -656,6 +658,8 @@ namespace BrokerageApi.Tests.V1.E2ETests
 
             var oneOffElementType = _fixture.BuildElementType(service.Id)
                 .With(et => et.CostType, ElementCostType.OneOff)
+                .With(et => et.CostOperation, MathOperation.Ignore)
+                .With(et => et.PaymentOperation, MathOperation.Ignore)
                 .Create();
 
             var referral = _fixture.BuildReferral(ReferralStatus.AwaitingApproval)

--- a/BrokerageApi.Tests/V1/E2ETests/ReferralTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/ReferralTests.cs
@@ -765,6 +765,8 @@ namespace BrokerageApi.Tests.V1.E2ETests
 
             var elementType = _fixture.BuildElementType(service.Id)
                 .With(et => et.CostType, ElementCostType.OneOff)
+                .With(et => et.CostOperation, MathOperation.Ignore)
+                .With(et => et.PaymentOperation, MathOperation.Ignore)
                 .Create();
 
             var belowLimitElement = _fixture.BuildElement(elementType.Id, provider.Id)

--- a/BrokerageApi.Tests/V1/E2ETests/ServiceUserTests.cs
+++ b/BrokerageApi.Tests/V1/E2ETests/ServiceUserTests.cs
@@ -47,6 +47,8 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 ServiceId = 1,
                 Name = "Day Opportunities (hourly)",
                 CostType = ElementCostType.Hourly,
+                CostOperation = MathOperation.Add,
+                PaymentOperation = MathOperation.Add,
                 NonPersonalBudget = false,
                 IsArchived = false
             };
@@ -57,6 +59,8 @@ namespace BrokerageApi.Tests.V1.E2ETests
                 ServiceId = 2,
                 Name = "Day Opportunities (daily)",
                 CostType = ElementCostType.Daily,
+                CostOperation = MathOperation.Add,
+                PaymentOperation = MathOperation.Add,
                 NonPersonalBudget = false,
                 IsArchived = false
             };
@@ -126,9 +130,9 @@ namespace BrokerageApi.Tests.V1.E2ETests
                         ParentElementId = null,
                         StartDate = startDate,
                         EndDate = null,
-                        Wednesday = new ElementCost(1, -100),
+                        Wednesday = new ElementCost(1, 100),
                         Quantity = 1,
-                        Cost = -100,
+                        Cost = 100,
                         CreatedAt = CurrentInstant,
                         UpdatedAt = CurrentInstant
                     },
@@ -176,8 +180,8 @@ namespace BrokerageApi.Tests.V1.E2ETests
 
             Assert.That(response[0].Id, Is.EqualTo(referral.Id));
             Assert.That(response[0].StartDate, Is.EqualTo(previousStartDate));
-            Assert.That(response[0].WeeklyCost, Is.EqualTo(225));
-            Assert.That(response[0].WeeklyPayment, Is.EqualTo(125));
+            Assert.That(response[0].WeeklyCost, Is.EqualTo(325));
+            Assert.That(response[0].WeeklyPayment, Is.EqualTo(325));
             Assert.That(response[0].Elements.Count, Is.EqualTo(2));
             Assert.That(response[0].CarePackageName, Is.EqualTo("A Different Service, Supported Living"));
 
@@ -209,7 +213,7 @@ namespace BrokerageApi.Tests.V1.E2ETests
 
             await Context.SaveChangesAsync();
             Context.ChangeTracker.Clear();
-            //Act 
+            //Act
             var (code, response) = await Get<List<ServiceUserResponse>>($"/api/v1/service-users/?SocialCareId={serviceUser.SocialCareId}");
             // Assert
             Assert.That(response, Has.Count.EqualTo(1));

--- a/BrokerageApi.Tests/V1/Gateways/CarePackageGatewayTests.cs
+++ b/BrokerageApi.Tests/V1/Gateways/CarePackageGatewayTests.cs
@@ -42,6 +42,8 @@ namespace BrokerageApi.Tests.V1.Gateways
             var oneOffElementType = Fixture.BuildElementType(service.Id)
                 .With(et => et.CostType, ElementCostType.OneOff)
                 .With(et => et.NonPersonalBudget, false)
+                .With(et => et.CostOperation, MathOperation.Ignore)
+                .With(et => et.PaymentOperation, MathOperation.Ignore)
                 .Create();
 
             var provider = Fixture.BuildProvider()
@@ -56,7 +58,7 @@ namespace BrokerageApi.Tests.V1.Gateways
 
             var dailyElement = Fixture.BuildElement(dailyElementType.Id, provider.Id)
                 .With(e => e.StartDate, startDate)
-                .With(e => e.Cost, Fixture.CreateInt(-1000, -1))
+                .With(e => e.Cost, Fixture.CreateInt(1, 1000))
                 .Create();
 
             var oneOffElement = Fixture.BuildElement(oneOffElementType.Id, provider.Id)
@@ -70,7 +72,7 @@ namespace BrokerageApi.Tests.V1.Gateways
                 })
                 .Create();
 
-            var expectedWeeklyCost = hourlyElement.Cost;
+            var expectedWeeklyCost = hourlyElement.Cost + dailyElement.Cost;
             var expectedWeeklyPayment = hourlyElement.Cost + dailyElement.Cost;
             var expectedYearlyPayment = (expectedWeeklyPayment * 52) + oneOffElement.Cost;
 
@@ -129,6 +131,8 @@ namespace BrokerageApi.Tests.V1.Gateways
                 ServiceId = 1,
                 Name = "Day Opportunities (hourly)",
                 CostType = ElementCostType.Hourly,
+                CostOperation = MathOperation.Add,
+                PaymentOperation = MathOperation.Add,
                 NonPersonalBudget = false,
                 IsArchived = false
             };
@@ -139,6 +143,8 @@ namespace BrokerageApi.Tests.V1.Gateways
                 ServiceId = 2,
                 Name = "Day Opportunities (daily)",
                 CostType = ElementCostType.Daily,
+                CostOperation = MathOperation.Add,
+                PaymentOperation = MathOperation.Add,
                 NonPersonalBudget = false,
                 IsArchived = false
             };
@@ -230,9 +236,9 @@ namespace BrokerageApi.Tests.V1.Gateways
                         ParentElementId = null,
                         StartDate = startDate,
                         EndDate = null,
-                        Wednesday = new ElementCost(1, -100),
+                        Wednesday = new ElementCost(1, 100),
                         Quantity = 1,
-                        Cost = -100,
+                        Cost = 100,
                         CreatedAt = CurrentInstant,
                         UpdatedAt = CurrentInstant
                     },
@@ -258,8 +264,8 @@ namespace BrokerageApi.Tests.V1.Gateways
             // Assert
             Assert.That(result.ElementAt(0).Id, Is.EqualTo(referral.Id));
             Assert.That(result.ElementAt(0).StartDate, Is.EqualTo(startDate));
-            Assert.That(result.ElementAt(0).WeeklyCost, Is.EqualTo(225));
-            Assert.That(result.ElementAt(0).WeeklyPayment, Is.EqualTo(125));
+            Assert.That(result.ElementAt(0).WeeklyCost, Is.EqualTo(325));
+            Assert.That(result.ElementAt(0).WeeklyPayment, Is.EqualTo(325));
             Assert.That(result.ElementAt(0).Elements.Count, Is.EqualTo(2));
             Assert.That(result.ElementAt(0).CarePackageName, Is.EqualTo("A Different Service, Supported Living"));
 
@@ -294,6 +300,8 @@ namespace BrokerageApi.Tests.V1.Gateways
 
             var elementType = Fixture.BuildElementType(service.Id)
                 .With(et => et.CostType, ElementCostType.OneOff)
+                .With(et => et.CostOperation, MathOperation.Ignore)
+                .With(et => et.PaymentOperation, MathOperation.Ignore)
                 .Create();
 
             var belowLimitElement = Fixture.BuildElement(elementType.Id, provider.Id)

--- a/BrokerageApi.Tests/V1/Helpers/FixtureHelpers.cs
+++ b/BrokerageApi.Tests/V1/Helpers/FixtureHelpers.cs
@@ -67,6 +67,8 @@ namespace BrokerageApi.Tests.V1.Helpers
                 .Without(et => et.Elements)
                 .With(et => et.ServiceId, serviceId)
                 .With(et => et.Type, type)
+                .With(et => et.CostOperation, MathOperation.Add)
+                .With(et => et.PaymentOperation, MathOperation.Add)
                 .With(et => et.IsArchived, false);
         }
         public static IPostprocessComposer<Referral> BuildReferral(this IFixture fixture, ReferralStatus? status = null)
@@ -101,6 +103,7 @@ namespace BrokerageApi.Tests.V1.Helpers
                 .Without(e => e.SuspensionElements)
                 .Without(e => e.Provider)
                 .Without(e => e.ElementType)
+                .Without(e => e.EndDate)
                 .With(e => e.ProviderId, providerId)
                 .With(e => e.ElementTypeId, elementTypeId)
                 .With(e => e.InternalStatus, ElementStatus.InProgress)

--- a/BrokerageApi.Tests/V1/UseCase/CarePackageCareCharges/ResetCareChargesUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackageCareCharges/ResetCareChargesUseCaseTests.cs
@@ -75,7 +75,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageCareCharges
             await _classUnderTest.ExecuteAsync(referral.Id, element.Id);
 
             referralElement.PendingEndDate.Should().BeNull();
-            referralElement.PendingCancellation.Should().BeNull();
+            referralElement.PendingCancellation.Should().BeFalse();
             referralElement.PendingComment.Should().BeNull();
             _dbSaver.VerifyChangesSaved();
             _mockDeleteCareChargeUseCase.Verify(x => x.ExecuteAsync(referral.Id, element.Id), Times.Never);

--- a/BrokerageApi.Tests/V1/UseCase/CarePackageElements/ResetElementUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackageElements/ResetElementUseCaseTests.cs
@@ -75,7 +75,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackageElements
             await _classUnderTest.ExecuteAsync(referral.Id, element.Id);
 
             referralElement.PendingEndDate.Should().BeNull();
-            referralElement.PendingCancellation.Should().BeNull();
+            referralElement.PendingCancellation.Should().BeFalse();
             referralElement.PendingComment.Should().BeNull();
             _dbSaver.VerifyChangesSaved();
             _mockDeleteElementUseCase.Verify(x => x.ExecuteAsync(referral.Id, element.Id), Times.Never);

--- a/BrokerageApi.Tests/V1/UseCase/CarePackages/ApproveCarePackageUseCaseTests.cs
+++ b/BrokerageApi.Tests/V1/UseCase/CarePackages/ApproveCarePackageUseCaseTests.cs
@@ -267,7 +267,7 @@ namespace BrokerageApi.Tests.V1.UseCase.CarePackages
             if (expectedCancellation.HasValue && expectedCancellation.Value)
             {
                 element.InternalStatus.Should().Be(ElementStatus.Cancelled);
-                referralElement.PendingCancellation.Should().BeNull();
+                referralElement.PendingCancellation.Should().BeFalse();
             }
 
             referralElement.PendingEndDate.Should().BeNull();

--- a/BrokerageApi/V1/Infrastructure/BrokerageContext.cs
+++ b/BrokerageApi/V1/Infrastructure/BrokerageContext.cs
@@ -177,6 +177,14 @@ namespace BrokerageApi.V1.Infrastructure
                 .HasDefaultValue(ElementBillingType.Supplier);
 
             modelBuilder.Entity<ElementType>()
+                .Property(et => et.CostOperation)
+                .HasDefaultValue(MathOperation.Ignore);
+
+            modelBuilder.Entity<ElementType>()
+                .Property(et => et.PaymentOperation)
+                .HasDefaultValue(MathOperation.Ignore);
+
+            modelBuilder.Entity<ElementType>()
                 .Property(et => et.NonPersonalBudget)
                 .HasDefaultValue(false);
 
@@ -231,6 +239,10 @@ namespace BrokerageApi.V1.Infrastructure
                     {
                         j.HasKey(re => new { re.ElementId, re.ReferralId });
                     });
+
+            modelBuilder.Entity<ReferralElement>()
+                .Property(re => re.PendingCancellation)
+                .HasDefaultValue(false);
 
             modelBuilder.Entity<Service>()
                 .Property(s => s.Id)

--- a/BrokerageApi/V1/Infrastructure/ElementType.cs
+++ b/BrokerageApi/V1/Infrastructure/ElementType.cs
@@ -23,6 +23,10 @@ namespace BrokerageApi.V1.Infrastructure
 
         public ElementBillingType Billing { get; set; }
 
+        public MathOperation CostOperation { get; set; }
+
+        public MathOperation PaymentOperation { get; set; }
+
         public bool NonPersonalBudget { get; set; }
 
         public bool IsS117 { get; set; }

--- a/BrokerageApi/V1/Infrastructure/MathOperation.cs
+++ b/BrokerageApi/V1/Infrastructure/MathOperation.cs
@@ -1,0 +1,13 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Converters;
+
+namespace BrokerageApi.V1.Infrastructure
+{
+    [JsonConverter(typeof(StringEnumConverter))]
+    public enum MathOperation
+    {
+        Subtract = -1,
+        Ignore = 0,
+        Add = 1
+    }
+}

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220712154921_AddCostAndPaymentOperationsToElementType.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220712154921_AddCostAndPaymentOperationsToElementType.Designer.cs
@@ -5,6 +5,7 @@ using BrokerageApi.V1.Infrastructure;
 using BrokerageApi.V1.Infrastructure.AuditEvents;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -15,9 +16,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220712154921_AddCostAndPaymentOperationsToElementType")]
+    partial class AddCostAndPaymentOperationsToElementType
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -630,10 +632,8 @@ namespace V1.Infrastructure.Migrations
                         .HasColumnType("integer")
                         .HasColumnName("referral_id");
 
-                    b.Property<bool>("PendingCancellation")
-                        .ValueGeneratedOnAdd()
+                    b.Property<bool?>("PendingCancellation")
                         .HasColumnType("boolean")
-                        .HasDefaultValue(false)
                         .HasColumnName("pending_cancellation");
 
                     b.Property<string>("PendingComment")

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220712154921_AddCostAndPaymentOperationsToElementType.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220712154921_AddCostAndPaymentOperationsToElementType.cs
@@ -1,0 +1,37 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class AddCostAndPaymentOperationsToElementType : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "cost_operation",
+                table: "element_types",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+
+            migrationBuilder.AddColumn<int>(
+                name: "payment_operation",
+                table: "element_types",
+                type: "integer",
+                nullable: false,
+                defaultValue: 0);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "cost_operation",
+                table: "element_types");
+
+            migrationBuilder.DropColumn(
+                name: "payment_operation",
+                table: "element_types");
+        }
+    }
+}

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220713102649_ConvertPendingCancellationToNotNull.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220713102649_ConvertPendingCancellationToNotNull.Designer.cs
@@ -5,6 +5,7 @@ using BrokerageApi.V1.Infrastructure;
 using BrokerageApi.V1.Infrastructure.AuditEvents;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -15,9 +16,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220713102649_ConvertPendingCancellationToNotNull")]
+    partial class ConvertPendingCancellationToNotNull
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220713102649_ConvertPendingCancellationToNotNull.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220713102649_ConvertPendingCancellationToNotNull.cs
@@ -1,0 +1,40 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class ConvertPendingCancellationToNotNull : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql(@"
+                UPDATE referral_elements
+                SET pending_cancellation = false
+                WHERE pending_cancellation IS NULL
+            ");
+
+            migrationBuilder.AlterColumn<bool>(
+                name: "pending_cancellation",
+                table: "referral_elements",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<bool>(
+                name: "pending_cancellation",
+                table: "referral_elements",
+                type: "boolean",
+                nullable: true,
+                oldClrType: typeof(bool),
+                oldType: "boolean",
+                oldDefaultValue: false);
+        }
+    }
+}

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220713110739_UpdateWeeklyCostAndPaymentViews.Designer.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220713110739_UpdateWeeklyCostAndPaymentViews.Designer.cs
@@ -5,6 +5,7 @@ using BrokerageApi.V1.Infrastructure;
 using BrokerageApi.V1.Infrastructure.AuditEvents;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using NodaTime;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
@@ -15,9 +16,10 @@ using NpgsqlTypes;
 namespace V1.Infrastructure.Migrations
 {
     [DbContext(typeof(BrokerageContext))]
-    partial class BrokerageContextModelSnapshot : ModelSnapshot
+    [Migration("20220713110739_UpdateWeeklyCostAndPaymentViews")]
+    partial class UpdateWeeklyCostAndPaymentViews
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -630,10 +632,8 @@ namespace V1.Infrastructure.Migrations
                         .HasColumnType("integer")
                         .HasColumnName("referral_id");
 
-                    b.Property<bool>("PendingCancellation")
-                        .ValueGeneratedOnAdd()
+                    b.Property<bool?>("PendingCancellation")
                         .HasColumnType("boolean")
-                        .HasDefaultValue(false)
                         .HasColumnName("pending_cancellation");
 
                     b.Property<string>("PendingComment")

--- a/BrokerageApi/V1/Infrastructure/Migrations/20220713110739_UpdateWeeklyCostAndPaymentViews.cs
+++ b/BrokerageApi/V1/Infrastructure/Migrations/20220713110739_UpdateWeeklyCostAndPaymentViews.cs
@@ -1,0 +1,172 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace V1.Infrastructure.Migrations
+{
+    public partial class UpdateWeeklyCostAndPaymentViews : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP VIEW care_packages");
+            migrationBuilder.Sql("DROP VIEW care_package_weekly_costs");
+            migrationBuilder.Sql("DROP VIEW care_package_weekly_payments");
+
+            migrationBuilder.Sql(@"
+                CREATE VIEW care_package_weekly_costs(referral_id, weekly_cost) as
+                SELECT
+                    r.id AS referral_id,
+                    sum(e.cost * et.cost_operation) AS weekly_cost
+                FROM referrals r
+                    JOIN referral_elements re ON r.id = re.referral_id
+                    JOIN elements e ON re.element_id = e.id
+                    JOIN element_types et on e.element_type_id = et.id
+                WHERE
+                    re.pending_cancellation IS FALSE
+                AND
+                    e.internal_status IN ('approved', 'in_progress', 'awaiting_approval')
+                AND
+                    (re.pending_end_date IS NULL OR re.pending_end_date > CURRENT_DATE)
+                AND
+                    (e.end_date IS NULL OR e.end_date > CURRENT_DATE)
+                GROUP BY r.id;
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE VIEW care_package_weekly_payments(referral_id, weekly_payment) as
+                SELECT
+                    r.id AS referral_id,
+                    sum(e.cost * et.payment_operation) AS weekly_payment
+                FROM referrals r
+                    JOIN referral_elements re ON r.id = re.referral_id
+                    JOIN elements e ON re.element_id = e.id
+                    JOIN element_types et on e.element_type_id = et.id
+                WHERE
+                    re.pending_cancellation IS FALSE
+                AND
+                    e.internal_status IN ('approved', 'in_progress', 'awaiting_approval')
+                AND
+                    (re.pending_end_date IS NULL OR re.pending_end_date > CURRENT_DATE)
+                AND
+                    (e.end_date IS NULL OR e.end_date > CURRENT_DATE)
+                GROUP BY r.id;
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE VIEW care_packages AS
+                SELECT
+                    r.id,
+                    r.workflow_id,
+                    r.workflow_type,
+                    r.form_name,
+                    r.social_care_id,
+                    r.resident_name,
+                    r.primary_support_reason,
+                    r.urgent_since,
+		            n.care_package_name,
+                    r.assigned_broker_email AS assigned_broker_id,
+                    r.assigned_approver_email AS assigned_approver_id,
+                    r.status,
+                    r.note,
+                    r.started_at,
+                    r.created_at,
+                    r.updated_at,
+                    d.start_date,
+                    r.care_charges_confirmed_at,
+                    c.weekly_cost,
+                    p.weekly_payment,
+                    o.one_off_payment,
+                    r.comment,
+                    (COALESCE(p.weekly_payment, 0) * 52) + COALESCE(o.one_off_payment, 0) AS estimated_yearly_cost
+                FROM
+                    referrals AS r
+                LEFT JOIN
+                    care_package_start_dates AS d ON r.id = d.referral_id
+                LEFT JOIN
+                    care_package_weekly_costs AS c ON r.id = c.referral_id
+                LEFT JOIN
+                    care_package_weekly_payments AS p ON r.id = p.referral_id
+                LEFT JOIN
+                    care_package_name AS n ON r.id = n.referral_id
+                LEFT JOIN
+                    care_package_one_off_payment AS o ON r.id = o.referral_id
+            ");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("DROP VIEW care_packages");
+            migrationBuilder.Sql("DROP VIEW care_package_weekly_costs");
+            migrationBuilder.Sql("DROP VIEW care_package_weekly_payments");
+
+            migrationBuilder.Sql(@"
+                CREATE VIEW care_package_weekly_costs(referral_id, weekly_cost) as
+                SELECT
+                    r.id AS referral_id,
+                    sum(e.cost) AS weekly_cost
+                FROM referrals r
+                    JOIN referral_elements re ON r.id = re.referral_id
+                    JOIN elements e ON re.element_id = e.id
+                    JOIN element_types et on e.element_type_id = et.id
+                WHERE
+                    e.cost > 0::numeric
+                    AND et.cost_type != 'one_off'
+                GROUP BY r.id;
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE VIEW care_package_weekly_payments(referral_id, weekly_payment) as
+                SELECT
+                    r.id AS referral_id,
+                    sum(e.cost) AS weekly_payment
+                FROM referrals r
+                    JOIN referral_elements re ON r.id = re.referral_id
+                    JOIN elements e ON re.element_id = e.id
+                    JOIN element_types et on e.element_type_id = et.id
+                WHERE
+                    et.cost_type != 'one_off'
+                GROUP BY r.id;
+            ");
+
+            migrationBuilder.Sql(@"
+                CREATE VIEW care_packages AS
+                SELECT
+                    r.id,
+                    r.workflow_id,
+                    r.workflow_type,
+                    r.form_name,
+                    r.social_care_id,
+                    r.resident_name,
+                    r.primary_support_reason,
+                    r.urgent_since,
+		            n.care_package_name,
+                    r.assigned_broker_email AS assigned_broker_id,
+                    r.assigned_approver_email AS assigned_approver_id,
+                    r.status,
+                    r.note,
+                    r.started_at,
+                    r.created_at,
+                    r.updated_at,
+                    d.start_date,
+                    r.care_charges_confirmed_at,
+                    c.weekly_cost,
+                    p.weekly_payment,
+                    o.one_off_payment,
+                    r.comment,
+                    (COALESCE(p.weekly_payment, 0) * 52) + COALESCE(o.one_off_payment, 0) AS estimated_yearly_cost
+                FROM
+                    referrals AS r
+                LEFT JOIN
+                    care_package_start_dates AS d ON r.id = d.referral_id
+                LEFT JOIN
+                    care_package_weekly_costs AS c ON r.id = c.referral_id
+                LEFT JOIN
+                    care_package_weekly_payments AS p ON r.id = p.referral_id
+                LEFT JOIN
+                    care_package_name AS n ON r.id = n.referral_id
+                LEFT JOIN
+                    care_package_one_off_payment AS o ON r.id = o.referral_id
+            ");
+        }
+    }
+}

--- a/BrokerageApi/V1/Infrastructure/ReferralElement.cs
+++ b/BrokerageApi/V1/Infrastructure/ReferralElement.cs
@@ -14,7 +14,7 @@ namespace BrokerageApi.V1.Infrastructure
         public LocalDate?
         PendingEndDate
         { get; set; }
-        public bool? PendingCancellation { get; set; }
+        public bool PendingCancellation { get; set; }
         [CanBeNull]
         public string PendingComment { get; set; }
     }

--- a/BrokerageApi/V1/UseCase/CarePackageCareCharges/ResetCareChargeUseCase.cs
+++ b/BrokerageApi/V1/UseCase/CarePackageCareCharges/ResetCareChargeUseCase.cs
@@ -62,7 +62,7 @@ namespace BrokerageApi.V1.UseCase.CarePackageCareCharges
         private async Task ResetApprovedElement(Referral referral, Element element)
         {
             var referralElement = referral.ReferralElements.Single(re => re.ElementId == element.Id);
-            referralElement.PendingCancellation = null;
+            referralElement.PendingCancellation = false;
             referralElement.PendingEndDate = null;
             referralElement.PendingComment = null;
 

--- a/BrokerageApi/V1/UseCase/CarePackageElements/ResetElementUseCase.cs
+++ b/BrokerageApi/V1/UseCase/CarePackageElements/ResetElementUseCase.cs
@@ -62,7 +62,7 @@ namespace BrokerageApi.V1.UseCase.CarePackageElements
         private async Task ResetApprovedElement(Referral referral, Element element)
         {
             var referralElement = referral.ReferralElements.Single(re => re.ElementId == element.Id);
-            referralElement.PendingCancellation = null;
+            referralElement.PendingCancellation = false;
             referralElement.PendingEndDate = null;
             referralElement.PendingComment = null;
 

--- a/BrokerageApi/V1/UseCase/CarePackages/ApproveCarePackageUseCase.cs
+++ b/BrokerageApi/V1/UseCase/CarePackages/ApproveCarePackageUseCase.cs
@@ -121,10 +121,10 @@ namespace BrokerageApi.V1.UseCase.CarePackages
                 await _auditGateway.AddAuditEvent(AuditEventType.ElementEnded, referral.SocialCareId, _userService.UserId, metadata);
             }
 
-            if (referralElement.PendingCancellation != null)
+            if (referralElement.PendingCancellation)
             {
                 e.InternalStatus = ElementStatus.Cancelled;
-                referralElement.PendingCancellation = null;
+                referralElement.PendingCancellation = false;
                 await _auditGateway.AddAuditEvent(AuditEventType.ElementCancelled, referral.SocialCareId, _userService.UserId, metadata);
             }
         }

--- a/data/seeds/element_types.csv
+++ b/data/seeds/element_types.csv
@@ -1,137 +1,137 @@
-"id","service_id","name","subjective_code","framework_subjective_code","type","cost_type","billing","non_personal_budget","position","is_archived","is_s117"
-1,1,"Shared Lives Hackney Adult Placement Scheme","520070",,"service","weekly","supplier",TRUE,101,FALSE,FALSE
-2,1,"Additional Needs Payment","520070",,"service","weekly","supplier",TRUE,102,FALSE,FALSE
-3,1,"Holiday Payment Hackney Adult Placement Scheme (Shared Lives)","520070",,"service","weekly","supplier",TRUE,103,FALSE,FALSE
-4,2,"Supported Living Core Costs/Accommodation (weekly)","520070",,"service","weekly","supplier",FALSE,201,FALSE,FALSE
-5,2,"Additional Needs Payment","520070",,"service","hourly","supplier",FALSE,202,FALSE,FALSE
-6,2,"Day Opportunities (hourly)","520070",,"service","hourly","supplier",FALSE,203,FALSE,FALSE
-7,2,"Day Opportunities (daily)","520070",,"service","daily","supplier",FALSE,204,FALSE,FALSE
-8,2,"Extra Hours (hourly)","520070",,"service","hourly","supplier",FALSE,205,FALSE,FALSE
-9,2,"Sleeping Nights (hourly)","520070",,"service","hourly","supplier",FALSE,206,FALSE,FALSE
-10,2,"Waking Nights (per night)","520070",,"service","daily","supplier",FALSE,207,FALSE,FALSE
-11,5,"Direct Payment - Day Care (weekly)","520085",,"service","weekly","supplier",FALSE,501,FALSE,FALSE
-12,5,"Direct Payment - Personal Care (hourly)","520085",,"service","hourly","supplier",FALSE,502,FALSE,FALSE
-13,5,"Direct Payment - Personal Care (weekly)","520085",,"service","weekly","supplier",FALSE,503,FALSE,FALSE
-14,5,"Direct Payment - Transport (weekly)","520085",,"service","transport","supplier",FALSE,504,FALSE,FALSE
-15,5,"Direct Payment (One off set up cost)","520085",,"service","one_off","supplier",FALSE,505,FALSE,FALSE
-16,5,"Direct Payment (other one off payment)","520085",,"service","one_off","supplier",FALSE,506,FALSE,FALSE
-17,5,"Direct Payment (Carer Respite one off payment)","520085",,"service","one_off","supplier",FALSE,507,FALSE,FALSE
-18,5,"Direct Payment Clawback (from service user)","520085",,"service","weekly","supplier",FALSE,508,FALSE,FALSE
-19,5,"Direct Payment to third party - Day Care (weekly)","520085",,"service","weekly","supplier",FALSE,509,FALSE,FALSE
-20,5,"Direct Payment to third party - Personal Care (hourly)","520085",,"service","hourly","supplier",FALSE,510,FALSE,FALSE
-21,5,"Direct Payment to third party - Personal Care (weekly)","520085",,"service","weekly","supplier",FALSE,511,FALSE,FALSE
-22,5,"Direct Payment to third party - Transport (weekly)","520085",,"service","transport","supplier",FALSE,512,FALSE,FALSE
-23,5,"Direct Payment to third party (once off set up cost)","520085",,"service","one_off","supplier",FALSE,513,FALSE,FALSE
-24,5,"Direct Payment to third party (other one off payments)","520085",,"service","one_off","supplier",FALSE,514,FALSE,FALSE
-25,5,"Direct Payment to third party (Carer respite one off payment)","520085",,"service","one_off","supplier",FALSE,515,FALSE,FALSE
-26,6,"Day opportunity (hourly)","520110",,"service","hourly","supplier",FALSE,601,FALSE,FALSE
-27,6,"Day opportunity - external provider (daily)","520110",,"service","daily","supplier",FALSE,602,FALSE,FALSE
-28,6,"Day opportunity - internal provider (daily)","520055",,"service","daily","none",FALSE,603,FALSE,FALSE
-29,6,"Day opportunity - transport - external provider","520110",,"service","transport","supplier",FALSE,604,FALSE,FALSE
-30,6,"Day opportunity - transport - internal provider","520075",,"service","transport","none",FALSE,605,FALSE,FALSE
-31,7,"Personal Home Care (hourly)","520050","520060","service","hourly","supplier",FALSE,701,FALSE,FALSE
-32,7,"Personal Home Care (weekly)","520050","520061","service","weekly","supplier",FALSE,702,FALSE,FALSE
-33,7,"Personal Home Care - Additional Carer (hourly)","520050","520058","service","hourly","supplier",FALSE,703,FALSE,FALSE
-34,7,"Escort (hourly)","520050","520054","service","hourly","supplier",FALSE,704,FALSE,FALSE
-35,7,"Live in Carer (hourly)","520050","520055","service","hourly","supplier",FALSE,705,FALSE,FALSE
-36,7,"Live in Carer (daily)","520050","520056","service","weekly","supplier",FALSE,706,FALSE,FALSE
-37,7,"Sleeping Nights (hourly)","520050","520062","service","hourly","supplier",FALSE,707,FALSE,FALSE
-38,7,"Sleeping Nights (cost per night)","520050","520063","service","daily","supplier",FALSE,708,FALSE,FALSE
-39,7,"Waking Nights (hourly)","520050","520064","service","hourly","supplier",FALSE,709,FALSE,FALSE
-40,7,"Waking Nights (cost per night)","520050","520065","service","daily","supplier",FALSE,710,FALSE,FALSE
-41,8,"Subsistence ASC (weekly)","520110",,"service","weekly","none",FALSE,801,FALSE,FALSE
-42,8,"Temporary Accommodation (cost per night)","520110",,"service","daily","none",TRUE,802,FALSE,FALSE
-43,9,"Temporary Accommodation (cost per night)","520110",,"service","daily","none",TRUE,901,FALSE,FALSE
-44,9,"Intense Clean","520110",,"service","one_off","none",TRUE,902,FALSE,FALSE
-45,10,"Housing with Care - external provider (hourly amount)","520110",,"service","hourly","none",FALSE,1001,FALSE,FALSE
-46,10,"Housing with Care - internal provider (hourly amount)","520110",,"service","hourly","none",FALSE,1002,FALSE,FALSE
-47,10,"Additional Needs Payment","520110",,"service","hourly","none",FALSE,1003,FALSE,FALSE
-48,11,"Respite Nursing Care","520110",,"service","weekly","supplier",FALSE,1101,FALSE,FALSE
-49,11,"Respite Residential Care","520110",,"service","weekly","none",FALSE,1102,FALSE,FALSE
-50,11,"Day Opportunities Respite (hourly)","520110",,"service","hourly","none",FALSE,1103,FALSE,FALSE
-51,11,"Day Opportunities Respite (daily)","520110",,"service","daily","none",FALSE,1104,FALSE,FALSE
-52,11,"Carer Support - Day Sitting Service (hourly)","520110",,"service","hourly","none",FALSE,1105,FALSE,FALSE
-53,11,"Additional Needs Payment","520110",,"service","weekly","supplier",FALSE,1106,FALSE,FALSE
-54,11,"Carer BACS Payment - S2029 (one off)","520110",,"service","weekly","none",FALSE,1107,FALSE,FALSE
-55,11,"Carer Cheque Payment - (one off)","520110",,"service","weekly","none",FALSE,1108,FALSE,FALSE
-58,12,"Intense Clean","520110",,"service","one_off","none",TRUE,1201,FALSE,FALSE
-59,12,"Other professional services (hourly)","520110",,"service","hourly","none",TRUE,1202,FALSE,FALSE
-60,12,"Other professional services (daily)","520110",,"service","daily","none",TRUE,1203,FALSE,FALSE
-61,12,"Pet Kennelling (daily)","520110",,"service","daily","none",TRUE,1204,FALSE,FALSE
-62,12,"Pet Kennelling (weekly)","520110",,"service","weekly","none",TRUE,1205,FALSE,FALSE
-63,12,"Transport (weekly)","520110",,"service","transport","none",TRUE,1206,FALSE,FALSE
-64,13,"Long Stay Nursing Care","520045",,"service","weekly","supplier",FALSE,1301,FALSE,FALSE
-65,13,"Additional Needs Payment","520045",,"service","hourly","supplier",FALSE,1302,FALSE,FALSE
-66,13,"Personal Allowance Payment","520045",,"service","weekly","supplier",FALSE,1303,FALSE,FALSE
-68,13,"Agreed Council Top Up Payment ","520045",,"service","weekly","supplier",FALSE,1303,FALSE,FALSE
-69,13,"Third Party top up (payment to provider)","920130",,"service","weekly","supplier",FALSE,1304,FALSE,FALSE
-70,13,"Third Party top up (collected by Hackney)","920130",,"service","weekly","customer",FALSE,1305,FALSE,FALSE
-71,14,"Temporary Stay Nursing Care","520045",,"service","weekly","supplier",FALSE,1401,FALSE,FALSE
-72,14,"Additional Needs Payment","520045",,"service","weekly","supplier",FALSE,1402,FALSE,FALSE
-73,14,"Personal Allowance Payment","520045",,"service","weekly","supplier",FALSE,1403,FALSE,FALSE
-75,15,"Short Stay Nursing Care","520045",,"service","weekly","supplier",FALSE,1501,FALSE,FALSE
-76,15,"Additional Needs Payment","520045",,"service","weekly","supplier",FALSE,1502,FALSE,FALSE
-77,15,"Personal Allowance Payment","520045",,"service","weekly","supplier",FALSE,1503,FALSE,FALSE
-79,16,"Long Stay Residential Care","520040",,"service","weekly","supplier",FALSE,1601,FALSE,FALSE
-80,16,"Additional Needs Payment","520040",,"service","weekly","supplier",FALSE,1602,FALSE,FALSE
-81,16,"Personal Allowance Payment","520040",,"service","weekly","supplier",FALSE,1603,FALSE,FALSE
-82,16,"Day Opportunities (weekly)","520040",,"service","weekly","supplier",FALSE,1604,FALSE,FALSE
-83,16,"Agreed Council Top Up Payment","520040",,"service","weekly","supplier",FALSE,1605,FALSE,FALSE
-84,16,"Third Party top up (collected by provider)","920130",,"service","weekly","supplier",FALSE,1606,FALSE,FALSE
-85,16,"Third Party top up (collected by Hackney)","920130",,"service","weekly","customer",FALSE,1607,FALSE,FALSE
-86,17,"Short Stay Residential Care","520040",,"service","weekly","supplier",FALSE,1701,FALSE,FALSE
-87,17,"Additional Needs Payment","520040",,"service","weekly","supplier",FALSE,1702,FALSE,FALSE
-88,17,"Personal Allowance Payment","520040",,"service","weekly","supplier",FALSE,1703,FALSE,FALSE
-89,18,"Short Stay Residential Care","520040",,"service","weekly","supplier",FALSE,1801,FALSE,FALSE
-90,18,"Additional Needs Payment","520040",,"service","weekly","supplier",FALSE,1802,FALSE,FALSE
-91,18,"Personal Allowance Payment","520040",,"service","weekly","supplier",FALSE,1803,FALSE,FALSE
-201,11,"Service user is an S117 client","920128",,"provisional_care_charge","weekly","none",FALSE,1101,FALSE,TRUE
-202,11,"Provisional Residential respite charge (collected by provider)","920128",,"provisional_care_charge","weekly","supplier",FALSE,1102,FALSE,FALSE
-203,11,"Provisional Residential respite charge (collected by Hackney)","920128",,"provisional_care_charge","weekly","customer",FALSE,1103,FALSE,FALSE
-204,13,"Service user is an S117 client","920180",,"provisional_care_charge","weekly","none",FALSE,1301,FALSE,TRUE
-205,13,"Provisional Residential Care Charges (collected by provider)","920180",,"provisional_care_charge","weekly","supplier",FALSE,1302,FALSE,FALSE
-206,13,"Provisional Residential Care Charges (collected by Hackney)","920180",,"provisional_care_charge","weekly","customer",FALSE,1303,FALSE,FALSE
-207,14,"Service user is an S117 client","920180",,"provisional_care_charge","weekly","none",FALSE,1401,FALSE,TRUE
-208,14,"Provisional Residential Care Charges (collected by provider)","920180",,"provisional_care_charge","weekly","supplier",FALSE,1402,FALSE,FALSE
-209,14,"Provisional Residential Care Charges (collected by Hackney)","920180",,"provisional_care_charge","weekly","customer",FALSE,1403,FALSE,FALSE
-210,15,"Service user is an S117 client","920180",,"provisional_care_charge","weekly","none",FALSE,1501,FALSE,TRUE
-211,15,"Provisional Residential Care Charges (collected by provider)","920180",,"provisional_care_charge","weekly","supplier",FALSE,1502,FALSE,FALSE
-212,15,"Provisional Residential Care Charges (collected by Hackney)","920180",,"provisional_care_charge","weekly","customer",FALSE,1503,FALSE,FALSE
-213,16,"Service user is an S117 client","920180",,"provisional_care_charge","weekly","none",FALSE,1601,FALSE,TRUE
-214,16,"Provisional Residential Care Charges (collected by provider)","920180",,"provisional_care_charge","weekly","supplier",FALSE,1602,FALSE,FALSE
-215,16,"Provisional Residential Care Charges (collected by Hackney)","920180",,"provisional_care_charge","weekly","customer",FALSE,1603,FALSE,FALSE
-216,17,"Service user is an S117 client","920128",,"provisional_care_charge","weekly","none",FALSE,1701,FALSE,TRUE
-217,17,"Provisional Residential Care Charges (collected by provider)","920128",,"provisional_care_charge","weekly","customer",FALSE,1702,FALSE,FALSE
-218,17,"Provisional Residential Care Charges (collected by Hackney)","920128",,"provisional_care_charge","weekly","supplier",FALSE,1703,FALSE,FALSE
-219,18,"Service user is an S117 client","920128",,"provisional_care_charge","weekly","none",FALSE,1801,FALSE,TRUE
-220,18,"Provisional Residential Care Charges (collected by provider)","920128",,"provisional_care_charge","weekly","supplier",FALSE,1802,FALSE,FALSE
-221,18,"Provisional Residential Care Charges (collected by Hackney)","920128",,"provisional_care_charge","weekly","customer",FALSE,1803,FALSE,FALSE
-301,11,"Respite Residential Care Charges (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",FALSE,1101,FALSE,FALSE
-302,11,"Respite Residential Care Charges (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",FALSE,1102,FALSE,FALSE
-303,13,"Residential Care Charges weeks 1 to 12 (collected by provider)","920180",,"confirmed_care_charge","weekly","supplier",FALSE,1301,FALSE,FALSE
-304,13,"Residential Care Charges weeks 1 to 12 (collected by Hackney)","920180",,"confirmed_care_charge","weekly","customer",FALSE,1302,FALSE,FALSE
-305,13,"Residential Care Charges weeks 13 onwards (collected by provider)","920180",,"confirmed_care_charge","weekly","supplier",FALSE,1303,FALSE,FALSE
-306,13,"Residential Care Charges weeks 13 onwards (collected by Hackney)","920180",,"confirmed_care_charge","weekly","customer",FALSE,1304,FALSE,FALSE
-309,14,"Short Stay Residential Care Charges (collected by provider)","920180",,"confirmed_care_charge","weekly","supplier",FALSE,1402,FALSE,FALSE
-310,14,"Short Stay Residential Care Charges (collected by Hackney)","920180",,"confirmed_care_charge","weekly","customer",FALSE,1403,FALSE,FALSE
-312,15,"Short Stay Residential Care Charges (collected by provider)","920180",,"confirmed_care_charge","weekly","supplier",FALSE,1501,FALSE,FALSE
-313,15,"Short Stay Residential Care Charges (collected by Hackney)","920180",,"confirmed_care_charge","weekly","customer",FALSE,1502,FALSE,FALSE
-316,16,"Residential Care Charges weeks 1 to 12 (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",FALSE,1601,FALSE,FALSE
-317,16,"Residential Care Charges weeks 1 to 12 (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",FALSE,1602,FALSE,FALSE
-318,16,"Residential Care Charges weeks 13 onwards (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",FALSE,1603,FALSE,FALSE
-319,16,"Residential Care Charges weeks 13 onwards (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",FALSE,1604,FALSE,FALSE
-320,17,"Short Stay Residential Care Charges (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",FALSE,1701,FALSE,FALSE
-321,17,"Short Stay Residential Care Charges (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",FALSE,1702,FALSE,FALSE
-322,18,"Short Stay Residential Care Charges (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",FALSE,1801,FALSE,FALSE
-323,18,"Short Stay Residential Care Charges (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",FALSE,1802,FALSE,FALSE
-324,19,"Non-Residential Care Charges (deduct from DP)","920128",,"confirmed_care_charge","weekly","customer",FALSE,1901,FALSE,FALSE
-325,19,"Non-Residential Care Charges (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",FALSE,1902,FALSE,FALSE
-401,13,"FNCC Nursing Care","520215",,"service","weekly","supplier",FALSE,1306,FALSE,FALSE
-402,13,"FNCC Reclaim (collected by provider)","920210",,"nursing_care","weekly","supplier",FALSE,1307,FALSE,FALSE
-403,13,"FNCC Reclaim (collected by Hackney)","920210",,"nursing_care","weekly","ccg",FALSE,1308,FALSE,FALSE
-411,14,"FNCC Nursing Care","520215",,"service","weekly","supplier",FALSE,1404,FALSE,FALSE
-412,14,"FNCC Reclaim (collected by provider)","920210",,"nursing_care","weekly","supplier",FALSE,1405,FALSE,FALSE
-413,14,"FNCC Reclaim (collected by Hackney)","920210",,"nursing_care","weekly","ccg",FALSE,1406,FALSE,FALSE
-421,15,"FNCC Nursing Care","520215",,"service","weekly","supplier",FALSE,1504,FALSE,FALSE
-422,15,"FNCC Reclaim (collected by provider)","920210",,"nursing_care","weekly","supplier",FALSE,1505,FALSE,FALSE
-423,15,"FNCC Reclaim (collected by Hackney)","920210",,"nursing_care","weekly","ccg",FALSE,1506,FALSE,FALSE
+"id","service_id","name","subjective_code","framework_subjective_code","type","cost_type","billing","cost_operation","payment_operation","non_personal_budget","position","is_archived","is_s117"
+1,1,"Shared Lives Hackney Adult Placement Scheme","520070",,"service","weekly","supplier",1,1,TRUE,101,FALSE,FALSE
+2,1,"Additional Needs Payment","520070",,"service","weekly","supplier",1,1,TRUE,102,FALSE,FALSE
+3,1,"Holiday Payment Hackney Adult Placement Scheme (Shared Lives)","520070",,"service","weekly","supplier",1,1,TRUE,103,FALSE,FALSE
+4,2,"Supported Living Core Costs/Accommodation (weekly)","520070",,"service","weekly","supplier",1,1,FALSE,201,FALSE,FALSE
+5,2,"Additional Needs Payment","520070",,"service","hourly","supplier",1,1,FALSE,202,FALSE,FALSE
+6,2,"Day Opportunities (hourly)","520070",,"service","hourly","supplier",1,1,FALSE,203,FALSE,FALSE
+7,2,"Day Opportunities (daily)","520070",,"service","daily","supplier",1,1,FALSE,204,FALSE,FALSE
+8,2,"Extra Hours (hourly)","520070",,"service","hourly","supplier",1,1,FALSE,205,FALSE,FALSE
+9,2,"Sleeping Nights (hourly)","520070",,"service","hourly","supplier",1,1,FALSE,206,FALSE,FALSE
+10,2,"Waking Nights (per night)","520070",,"service","daily","supplier",1,1,FALSE,207,FALSE,FALSE
+11,5,"Direct Payment - Day Care (weekly)","520085",,"service","weekly","supplier",1,1,FALSE,501,FALSE,FALSE
+12,5,"Direct Payment - Personal Care (hourly)","520085",,"service","hourly","supplier",1,1,FALSE,502,FALSE,FALSE
+13,5,"Direct Payment - Personal Care (weekly)","520085",,"service","weekly","supplier",1,1,FALSE,503,FALSE,FALSE
+14,5,"Direct Payment - Transport (weekly)","520085",,"service","transport","supplier",1,1,FALSE,504,FALSE,FALSE
+15,5,"Direct Payment (One off set up cost)","520085",,"service","one_off","supplier",0,0,FALSE,505,FALSE,FALSE
+16,5,"Direct Payment (other one off payment)","520085",,"service","one_off","supplier",0,0,FALSE,506,FALSE,FALSE
+17,5,"Direct Payment (Carer Respite one off payment)","520085",,"service","one_off","supplier",0,0,FALSE,507,FALSE,FALSE
+18,5,"Direct Payment Clawback (from service user)","520085",,"service","weekly","supplier",0,-1,FALSE,508,FALSE,FALSE
+19,5,"Direct Payment to third party - Day Care (weekly)","520085",,"service","weekly","supplier",1,1,FALSE,509,FALSE,FALSE
+20,5,"Direct Payment to third party - Personal Care (hourly)","520085",,"service","hourly","supplier",1,1,FALSE,510,FALSE,FALSE
+21,5,"Direct Payment to third party - Personal Care (weekly)","520085",,"service","weekly","supplier",1,1,FALSE,511,FALSE,FALSE
+22,5,"Direct Payment to third party - Transport (weekly)","520085",,"service","transport","supplier",1,1,FALSE,512,FALSE,FALSE
+23,5,"Direct Payment to third party (once off set up cost)","520085",,"service","one_off","supplier",0,0,FALSE,513,FALSE,FALSE
+24,5,"Direct Payment to third party (other one off payments)","520085",,"service","one_off","supplier",0,0,FALSE,514,FALSE,FALSE
+25,5,"Direct Payment to third party (Carer respite one off payment)","520085",,"service","one_off","supplier",0,0,FALSE,515,FALSE,FALSE
+26,6,"Day opportunity (hourly)","520110",,"service","hourly","supplier",1,1,FALSE,601,FALSE,FALSE
+27,6,"Day opportunity - external provider (daily)","520110",,"service","daily","supplier",1,1,FALSE,602,FALSE,FALSE
+28,6,"Day opportunity - internal provider (daily)","520055",,"service","daily","none",1,1,FALSE,603,FALSE,FALSE
+29,6,"Day opportunity - transport - external provider","520110",,"service","transport","supplier",1,1,FALSE,604,FALSE,FALSE
+30,6,"Day opportunity - transport - internal provider","520075",,"service","transport","none",1,1,FALSE,605,FALSE,FALSE
+31,7,"Personal Home Care (hourly)","520050","520060","service","hourly","supplier",1,1,FALSE,701,FALSE,FALSE
+32,7,"Personal Home Care (weekly)","520050","520061","service","weekly","supplier",1,1,FALSE,702,FALSE,FALSE
+33,7,"Personal Home Care - Additional Carer (hourly)","520050","520058","service","hourly","supplier",1,1,FALSE,703,FALSE,FALSE
+34,7,"Escort (hourly)","520050","520054","service","hourly","supplier",1,1,FALSE,704,FALSE,FALSE
+35,7,"Live in Carer (hourly)","520050","520055","service","hourly","supplier",1,1,FALSE,705,FALSE,FALSE
+36,7,"Live in Carer (daily)","520050","520056","service","weekly","supplier",1,1,FALSE,706,FALSE,FALSE
+37,7,"Sleeping Nights (hourly)","520050","520062","service","hourly","supplier",1,1,FALSE,707,FALSE,FALSE
+38,7,"Sleeping Nights (cost per night)","520050","520063","service","daily","supplier",1,1,FALSE,708,FALSE,FALSE
+39,7,"Waking Nights (hourly)","520050","520064","service","hourly","supplier",1,1,FALSE,709,FALSE,FALSE
+40,7,"Waking Nights (cost per night)","520050","520065","service","daily","supplier",1,1,FALSE,710,FALSE,FALSE
+41,8,"Subsistence ASC (weekly)","520110",,"service","weekly","none",1,1,FALSE,801,FALSE,FALSE
+42,8,"Temporary Accommodation (cost per night)","520110",,"service","daily","none",1,1,TRUE,802,FALSE,FALSE
+43,9,"Temporary Accommodation (cost per night)","520110",,"service","daily","none",1,1,TRUE,901,FALSE,FALSE
+44,9,"Intense Clean","520110",,"service","one_off","none",0,0,TRUE,902,FALSE,FALSE
+45,10,"Housing with Care - external provider (hourly amount)","520110",,"service","hourly","none",1,1,FALSE,1001,FALSE,FALSE
+46,10,"Housing with Care - internal provider (hourly amount)","520110",,"service","hourly","none",1,1,FALSE,1002,FALSE,FALSE
+47,10,"Additional Needs Payment","520110",,"service","hourly","none",1,1,FALSE,1003,FALSE,FALSE
+48,11,"Respite Nursing Care","520110",,"service","weekly","supplier",1,1,FALSE,1101,FALSE,FALSE
+49,11,"Respite Residential Care","520110",,"service","weekly","none",1,1,FALSE,1102,FALSE,FALSE
+50,11,"Day Opportunities Respite (hourly)","520110",,"service","hourly","none",1,1,FALSE,1103,FALSE,FALSE
+51,11,"Day Opportunities Respite (daily)","520110",,"service","daily","none",1,1,FALSE,1104,FALSE,FALSE
+52,11,"Carer Support - Day Sitting Service (hourly)","520110",,"service","hourly","none",1,1,FALSE,1105,FALSE,FALSE
+53,11,"Additional Needs Payment","520110",,"service","weekly","supplier",1,1,FALSE,1106,FALSE,FALSE
+54,11,"Carer BACS Payment - S2029 (one off)","520110",,"service","weekly","none",1,1,FALSE,1107,FALSE,FALSE
+55,11,"Carer Cheque Payment - (one off)","520110",,"service","weekly","none",1,1,FALSE,1108,FALSE,FALSE
+58,12,"Intense Clean","520110",,"service","one_off","none",0,0,TRUE,1201,FALSE,FALSE
+59,12,"Other professional services (hourly)","520110",,"service","hourly","none",1,1,TRUE,1202,FALSE,FALSE
+60,12,"Other professional services (daily)","520110",,"service","daily","none",1,1,TRUE,1203,FALSE,FALSE
+61,12,"Pet Kennelling (daily)","520110",,"service","daily","none",1,1,TRUE,1204,FALSE,FALSE
+62,12,"Pet Kennelling (weekly)","520110",,"service","weekly","none",1,1,TRUE,1205,FALSE,FALSE
+63,12,"Transport (weekly)","520110",,"service","transport","none",1,1,TRUE,1206,FALSE,FALSE
+64,13,"Long Stay Nursing Care","520045",,"service","weekly","supplier",1,1,FALSE,1301,FALSE,FALSE
+65,13,"Additional Needs Payment","520045",,"service","hourly","supplier",1,1,FALSE,1302,FALSE,FALSE
+66,13,"Personal Allowance Payment","520045",,"service","weekly","supplier",1,1,FALSE,1303,FALSE,FALSE
+68,13,"Agreed Council Top Up Payment ","520045",,"service","weekly","supplier",1,1,FALSE,1303,FALSE,FALSE
+69,13,"Third Party top up (payment to provider)","920130",,"service","weekly","supplier",1,-1,FALSE,1304,FALSE,FALSE
+70,13,"Third Party top up (collected by Hackney)","920130",,"service","weekly","customer",1,0,FALSE,1305,FALSE,FALSE
+71,14,"Temporary Stay Nursing Care","520045",,"service","weekly","supplier",1,1,FALSE,1401,FALSE,FALSE
+72,14,"Additional Needs Payment","520045",,"service","weekly","supplier",1,1,FALSE,1402,FALSE,FALSE
+73,14,"Personal Allowance Payment","520045",,"service","weekly","supplier",1,1,FALSE,1403,FALSE,FALSE
+75,15,"Short Stay Nursing Care","520045",,"service","weekly","supplier",1,1,FALSE,1501,FALSE,FALSE
+76,15,"Additional Needs Payment","520045",,"service","weekly","supplier",1,1,FALSE,1502,FALSE,FALSE
+77,15,"Personal Allowance Payment","520045",,"service","weekly","supplier",1,1,FALSE,1503,FALSE,FALSE
+79,16,"Long Stay Residential Care","520040",,"service","weekly","supplier",1,1,FALSE,1601,FALSE,FALSE
+80,16,"Additional Needs Payment","520040",,"service","weekly","supplier",1,1,FALSE,1602,FALSE,FALSE
+81,16,"Personal Allowance Payment","520040",,"service","weekly","supplier",1,1,FALSE,1603,FALSE,FALSE
+82,16,"Day Opportunities (weekly)","520040",,"service","weekly","supplier",1,1,FALSE,1604,FALSE,FALSE
+83,16,"Agreed Council Top Up Payment","520040",,"service","weekly","supplier",1,1,FALSE,1605,FALSE,FALSE
+84,16,"Third Party top up (collected by provider)","920130",,"service","weekly","supplier",1,-1,FALSE,1606,FALSE,FALSE
+85,16,"Third Party top up (collected by Hackney)","920130",,"service","weekly","customer",1,0,FALSE,1607,FALSE,FALSE
+86,17,"Short Stay Residential Care","520040",,"service","weekly","supplier",1,1,FALSE,1701,FALSE,FALSE
+87,17,"Additional Needs Payment","520040",,"service","weekly","supplier",1,1,FALSE,1702,FALSE,FALSE
+88,17,"Personal Allowance Payment","520040",,"service","weekly","supplier",1,1,FALSE,1703,FALSE,FALSE
+89,18,"Short Stay Residential Care","520040",,"service","weekly","supplier",1,1,FALSE,1801,FALSE,FALSE
+90,18,"Additional Needs Payment","520040",,"service","weekly","supplier",1,1,FALSE,1802,FALSE,FALSE
+91,18,"Personal Allowance Payment","520040",,"service","weekly","supplier",1,1,FALSE,1803,FALSE,FALSE
+201,11,"Service user is an S117 client","920128",,"provisional_care_charge","weekly","none",0,0,FALSE,1101,FALSE,TRUE
+202,11,"Provisional Residential respite charge (collected by provider)","920128",,"provisional_care_charge","weekly","supplier",0,-1,FALSE,1102,FALSE,FALSE
+203,11,"Provisional Residential respite charge (collected by Hackney)","920128",,"provisional_care_charge","weekly","customer",0,0,FALSE,1103,FALSE,FALSE
+204,13,"Service user is an S117 client","920180",,"provisional_care_charge","weekly","none",0,0,FALSE,1301,FALSE,TRUE
+205,13,"Provisional Residential Care Charges (collected by provider)","920180",,"provisional_care_charge","weekly","supplier",0,-1,FALSE,1302,FALSE,FALSE
+206,13,"Provisional Residential Care Charges (collected by Hackney)","920180",,"provisional_care_charge","weekly","customer",0,0,FALSE,1303,FALSE,FALSE
+207,14,"Service user is an S117 client","920180",,"provisional_care_charge","weekly","none",0,0,FALSE,1401,FALSE,TRUE
+208,14,"Provisional Residential Care Charges (collected by provider)","920180",,"provisional_care_charge","weekly","supplier",0,-1,FALSE,1402,FALSE,FALSE
+209,14,"Provisional Residential Care Charges (collected by Hackney)","920180",,"provisional_care_charge","weekly","customer",0,0,FALSE,1403,FALSE,FALSE
+210,15,"Service user is an S117 client","920180",,"provisional_care_charge","weekly","none",0,0,FALSE,1501,FALSE,TRUE
+211,15,"Provisional Residential Care Charges (collected by provider)","920180",,"provisional_care_charge","weekly","supplier",0,-1,FALSE,1502,FALSE,FALSE
+212,15,"Provisional Residential Care Charges (collected by Hackney)","920180",,"provisional_care_charge","weekly","customer",0,0,FALSE,1503,FALSE,FALSE
+213,16,"Service user is an S117 client","920180",,"provisional_care_charge","weekly","none",0,0,FALSE,1601,FALSE,TRUE
+214,16,"Provisional Residential Care Charges (collected by provider)","920180",,"provisional_care_charge","weekly","supplier",0,-1,FALSE,1602,FALSE,FALSE
+215,16,"Provisional Residential Care Charges (collected by Hackney)","920180",,"provisional_care_charge","weekly","customer",0,0,FALSE,1603,FALSE,FALSE
+216,17,"Service user is an S117 client","920128",,"provisional_care_charge","weekly","none",0,0,FALSE,1701,FALSE,TRUE
+217,17,"Provisional Residential Care Charges (collected by provider)","920128",,"provisional_care_charge","weekly","customer",0,-1,FALSE,1702,FALSE,FALSE
+218,17,"Provisional Residential Care Charges (collected by Hackney)","920128",,"provisional_care_charge","weekly","supplier",0,0,FALSE,1703,FALSE,FALSE
+219,18,"Service user is an S117 client","920128",,"provisional_care_charge","weekly","none",0,0,FALSE,1801,FALSE,TRUE
+220,18,"Provisional Residential Care Charges (collected by provider)","920128",,"provisional_care_charge","weekly","supplier",0,-1,FALSE,1802,FALSE,FALSE
+221,18,"Provisional Residential Care Charges (collected by Hackney)","920128",,"provisional_care_charge","weekly","customer",0,0,FALSE,1803,FALSE,FALSE
+301,11,"Respite Residential Care Charges (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1101,FALSE,FALSE
+302,11,"Respite Residential Care Charges (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1102,FALSE,FALSE
+303,13,"Residential Care Charges weeks 1 to 12 (collected by provider)","920180",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1301,FALSE,FALSE
+304,13,"Residential Care Charges weeks 1 to 12 (collected by Hackney)","920180",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1302,FALSE,FALSE
+305,13,"Residential Care Charges weeks 13 onwards (collected by provider)","920180",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1303,FALSE,FALSE
+306,13,"Residential Care Charges weeks 13 onwards (collected by Hackney)","920180",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1304,FALSE,FALSE
+309,14,"Short Stay Residential Care Charges (collected by provider)","920180",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1402,FALSE,FALSE
+310,14,"Short Stay Residential Care Charges (collected by Hackney)","920180",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1403,FALSE,FALSE
+312,15,"Short Stay Residential Care Charges (collected by provider)","920180",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1501,FALSE,FALSE
+313,15,"Short Stay Residential Care Charges (collected by Hackney)","920180",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1502,FALSE,FALSE
+316,16,"Residential Care Charges weeks 1 to 12 (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1601,FALSE,FALSE
+317,16,"Residential Care Charges weeks 1 to 12 (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1602,FALSE,FALSE
+318,16,"Residential Care Charges weeks 13 onwards (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1603,FALSE,FALSE
+319,16,"Residential Care Charges weeks 13 onwards (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1604,FALSE,FALSE
+320,17,"Short Stay Residential Care Charges (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1701,FALSE,FALSE
+321,17,"Short Stay Residential Care Charges (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1702,FALSE,FALSE
+322,18,"Short Stay Residential Care Charges (collected by provider)","920128",,"confirmed_care_charge","weekly","supplier",0,-1,FALSE,1801,FALSE,FALSE
+323,18,"Short Stay Residential Care Charges (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1802,FALSE,FALSE
+324,19,"Non-Residential Care Charges (deduct from DP)","920128",,"confirmed_care_charge","weekly","customer",0,-1,FALSE,1901,FALSE,FALSE
+325,19,"Non-Residential Care Charges (collected by Hackney)","920128",,"confirmed_care_charge","weekly","customer",0,0,FALSE,1902,FALSE,FALSE
+401,13,"FNCC Nursing Care","520215",,"service","weekly","supplier",1,1,FALSE,1306,FALSE,FALSE
+402,13,"FNCC Reclaim (collected by provider)","920210",,"nursing_care","weekly","supplier",0,-1,FALSE,1307,FALSE,FALSE
+403,13,"FNCC Reclaim (collected by Hackney)","920210",,"nursing_care","weekly","ccg",0,0,FALSE,1308,FALSE,FALSE
+411,14,"FNCC Nursing Care","520215",,"service","weekly","supplier",1,1,FALSE,1404,FALSE,FALSE
+412,14,"FNCC Reclaim (collected by provider)","920210",,"nursing_care","weekly","supplier",0,-1,FALSE,1405,FALSE,FALSE
+413,14,"FNCC Reclaim (collected by Hackney)","920210",,"nursing_care","weekly","ccg",0,0,FALSE,1406,FALSE,FALSE
+421,15,"FNCC Nursing Care","520215",,"service","weekly","supplier",1,1,FALSE,1504,FALSE,FALSE
+422,15,"FNCC Reclaim (collected by provider)","920210",,"nursing_care","weekly","supplier",0,-1,FALSE,1505,FALSE,FALSE
+423,15,"FNCC Reclaim (collected by Hackney)","920210",,"nursing_care","weekly","ccg",0,0,FALSE,1506,FALSE,FALSE

--- a/data/seeds/update-element-types.sql
+++ b/data/seeds/update-element-types.sql
@@ -11,13 +11,15 @@ CREATE TEMPORARY TABLE element_types_update (
   cost_type element_cost_type NOT NULL,
   non_personal_budget boolean NOT NULL,
   billing element_billing_type NOT NULL,
+  cost_operation integer NOT NULL,
+  payment_operation integer NOT NULL,
   position integer NOT NULL,
   is_archived boolean NOT NULL,
   is_s117 boolean NOT NULL
 );
 
 -- Import element type updates
-\copy element_types_update(id, service_id, name, subjective_code, framework_subjective_code, type, cost_type, billing, non_personal_budget, position, is_archived, is_s117) FROM 'element_types.csv' CSV HEADER;
+\copy element_types_update(id, service_id, name, subjective_code, framework_subjective_code, type, cost_type, billing, cost_operation, payment_operation, non_personal_budget, position, is_archived, is_s117) FROM 'element_types.csv' CSV HEADER;
 
 -- Delete any element types
 DELETE FROM element_types WHERE id NOT IN (
@@ -27,11 +29,13 @@ DELETE FROM element_types WHERE id NOT IN (
 -- Update element types
 INSERT INTO element_types (
   id, service_id, name, subjective_code, framework_subjective_code,
-  type, cost_type, billing, non_personal_budget, position, is_archived, is_s117
+  type, cost_type, billing, cost_operation, payment_operation,
+  non_personal_budget, position, is_archived, is_s117
 )
 SELECT
   id, service_id, name, subjective_code, framework_subjective_code,
-  type, cost_type, billing, non_personal_budget, position, is_archived, is_s117
+  type, cost_type, billing, cost_operation, payment_operation,
+  non_personal_budget, position, is_archived, is_s117
 FROM
   element_types_update
 ON CONFLICT (id) DO UPDATE SET
@@ -43,6 +47,8 @@ ON CONFLICT (id) DO UPDATE SET
   cost_type = EXCLUDED.cost_type,
   non_personal_budget = EXCLUDED.non_personal_budget,
   billing = EXCLUDED.billing,
+  cost_operation = EXCLUDED.cost_operation,
+  payment_operation = EXCLUDED.payment_operation,
   position = EXCLUDED.position,
   is_archived = EXCLUDED.is_archived,
   is_s117 = EXCLUDED.is_s117;


### PR DESCRIPTION
1. Services like 'Home Care' are added to both cost and payment totals.
2. Care charges are subtracted from the payment total.
3. One-off payments are ignored.

In all cases if an element has ended, or is pending being ended/cancelled then it is ignored in both the weekly cost and payment totals.
